### PR TITLE
Release v9.2.2 - Fixed Share modal not always loading a route's MDT string

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -159,7 +159,7 @@ return [
                 'connection' => 'redis',
                 'queue'      => [sprintf('%s-production-thumbnail', env('APP_TYPE'))],
                 'balance'    => 'simple',
-                'processes'  => 8,
+                'processes'  => 6,
                 'tries'      => 1,
             ],
             'supervisor-thumbnail-api' => [

--- a/database/seeders/releases/9.2.2.json
+++ b/database/seeders/releases/9.2.2.json
@@ -1,0 +1,23 @@
+{
+    "id": 233,
+    "release_changelog_id": 240,
+    "version": "v9.2.2",
+    "title": "Fixed Share modal not always loading a route's MDT string",
+    "silent": 0,
+    "spotlight": 0,
+    "created_at": "2024-05-04T19:45:29+00:00",
+    "updated_at": "2024-05-04T19:45:29+00:00",
+    "changelog": {
+        "id": 240,
+        "release_id": 233,
+        "description": null,
+        "changes": [
+            {
+                "release_changelog_id": 240,
+                "release_changelog_category_id": 5,
+                "ticket_id": 2354,
+                "change": "Routes that produced warnings when generating an MDT string now properly show their MDT string (instead of crashing in the background)."
+            }
+        ]
+    }
+}

--- a/resources/assets/js/custom/inline/common/maps/map.js
+++ b/resources/assets/js/custom/inline/common/maps/map.js
@@ -545,7 +545,7 @@ class CommonMapsMap extends InlineCode {
 
                 // Inject the warnings, if there are any
                 if (json.warnings.length > 0) {
-                    (new MdtStringWarnings(json.warnings))
+                    (new MdtStringNoticesWarnings(json.warnings))
                         .render($('#mdt_export_result_warnings'));
                 }
 


### PR DESCRIPTION
Bugfixes:
  * #2354 Routes that produced warnings when generating an MDT string now properly show their MDT string (instead of crashing in the background).