### PR TITLE
Release v10.0.4 - Fixed MDT importer not working if you had comments in your route

### DIFF
--- a/app/Console/Commands/Traits/ConvertsMDTStrings.php
+++ b/app/Console/Commands/Traits/ConvertsMDTStrings.php
@@ -49,9 +49,10 @@ trait ConvertsMDTStrings
             if ($fileName !== null) {
                 $cmd = sprintf($encode ? self::$CLI_PARSER_ENCODE_CMD : self::$CLI_PARSER_DECODE_CMD, $fileName);
                 // Performing sudo on local environment causes issues - but we're already root then
-                if (config('app.type') !== 'local') {
-                    $cmd = sprintf('%s %s', self::$SUDO, $cmd);
-                }
+                // ^ okay what issues then genius? It works fine locally
+//                if (config('app.type') !== 'local') {
+                $cmd = sprintf('%s %s', self::$SUDO, $cmd);
+//                }
 
                 $process = new Process(explode(' ', $cmd));
                 $process->run();

--- a/app/Service/MDT/MDTImportStringService.php
+++ b/app/Service/MDT/MDTImportStringService.php
@@ -796,19 +796,20 @@ class MDTImportStringService extends MDTBaseService implements MDTImportStringSe
                 $mappingVersion,
                 $latLng
             );
-        }
 
-        if ($latLng->getFloor()->facade) {
-            $this->log->parseObjectCommentAfterConversionFloorStillOnFacade($latLng->toArrayWithFloor());
+            // @TODO this needs to be put everywhere in this class in a generic function of sorts, no time now
+            if ($latLng->getFloor()->facade) {
+                $this->log->parseObjectCommentAfterConversionFloorStillOnFacade($latLng->toArrayWithFloor());
 
-            $importStringObjects->getWarnings()->push(
-                new ImportWarning(
-                    __('logic.mdt.io.import_string.category.object'),
-                    __('logic.mdt.io.import_string.object_out_of_bounds', ['comment' => (string)$details['4']])
-                )
-            );
+                $importStringObjects->getWarnings()->push(
+                    new ImportWarning(
+                        __('logic.mdt.io.import_string.category.object'),
+                        __('logic.mdt.io.import_string.object_out_of_bounds', ['comment' => (string)$details['4']])
+                    )
+                );
 
-            return;
+                return;
+            }
         }
 
         $ingameXY = $this->coordinatesService->calculateIngameLocationForMapLocation($latLng);
@@ -817,8 +818,9 @@ class MDTImportStringService extends MDTBaseService implements MDTImportStringSe
         foreach ($importStringObjects->getKillZoneAttributes() as $killZoneIndex => $killZoneAttribute) {
             foreach ($killZoneAttribute['killZoneEnemies'] as $killZoneEnemy) {
                 $enemyIngameXY = $this->coordinatesService->calculateIngameLocationForMapLocation(
-                    new LatLng($killZoneEnemy['enemy']->lat, $killZoneEnemy['enemy']->lng, $floor)
+                    new LatLng($killZoneEnemy['enemy']->lat, $killZoneEnemy['enemy']->lng, $latLng->getFloor())
                 );
+
                 if ($this->coordinatesService->distanceBetweenPoints(
                         $enemyIngameXY->getX(), $ingameXY->getX(),
                         $enemyIngameXY->getY(), $ingameXY->getY()

--- a/database/seeders/releases/v10.0.4.json
+++ b/database/seeders/releases/v10.0.4.json
@@ -1,0 +1,23 @@
+{
+    "id": 238,
+    "release_changelog_id": 245,
+    "version": "v10.0.4",
+    "title": "Fixed MDT importer not working if you had comments in your route",
+    "silent": 0,
+    "spotlight": 0,
+    "created_at": "2024-05-17T08:53:42+00:00",
+    "updated_at": "2024-05-17T08:53:42+00:00",
+    "changelog": {
+        "id": 245,
+        "release_id": 238,
+        "description": null,
+        "changes": [
+            {
+                "release_changelog_id": 245,
+                "release_changelog_category_id": 5,
+                "ticket_id": 2379,
+                "change": "Fixed MDT importer not working if you had comments in your route. I added additional checks last release which exposed this bug and caused it to crash. As a result, any map comments next to your pulls (for Bloodlust~) are now automatically assigned as spells to your pulls as was intended."
+            }
+        ]
+    }
+}

--- a/docker-compose/app/Dockerfile
+++ b/docker-compose/app/Dockerfile
@@ -81,9 +81,6 @@ RUN apt-get update && apt-get install -y libssl-dev && \
 RUN /root/.cargo/bin/cargo install --git https://github.com/Zireael-N/cli-weakauras-parser.git && \
     ln -s ~/.cargo/bin/cli_weakauras_parser /usr/bin/cli_weakauras_parser
 
-# Give the www-data user rights to execute cli weakauras parser as sudo
-RUN echo "www-data ALL=NOPASSWD: /usr/bin/cli_weakauras_parser" >> /etc/sudoers
-
 # Install actual LUA language
 RUN apt-get update && apt-get install -y lua5.3 liblua5.3 && \
     ln -s /usr/include/lua5.3/ /usr/include/lua && \
@@ -112,7 +109,9 @@ RUN unzip /tmp/LuaBitOp-1.0.3.zip -d /tmp && \
     cp bit.so /usr/lib/lua/5.3/
 
 # Setup files/folders
-COPY etc/crontab /etc/crontab
+COPY etc/ /etc/
+
+RUN chmod -R 440 /etc/sudoers.d/
 
 COPY var/ /var/
 

--- a/docker-compose/app/etc/sudoers.d/cli_weakauras_parser
+++ b/docker-compose/app/etc/sudoers.d/cli_weakauras_parser
@@ -1,0 +1,2 @@
+www-data ALL=(ALL) NOPASSWD: /usr/bin/cli_weakauras_parser
+www-data ALL=(ALL) NOPASSWD: /root/.cargo/bin/cli_weakauras_parser


### PR DESCRIPTION
Bugfixes:
  * #2379 Fixed MDT importer not working if you had comments in your route. I added additional checks last release which exposed this bug and caused it to crash. As a result, any map comments next to your pulls (for Bloodlust~) are now automatically assigned as spells to your pulls as was intended.