### PR TITLE
Release v10.0.5 - Fixed search page not working before switching tabs

### DIFF
--- a/database/seeders/releases/v10.0.5.json
+++ b/database/seeders/releases/v10.0.5.json
@@ -1,0 +1,23 @@
+{
+    "id": 239,
+    "release_changelog_id": 246,
+    "version": "v10.0.5",
+    "title": "Fixed search page not working before switching tabs",
+    "silent": 0,
+    "spotlight": 0,
+    "created_at": "2024-05-25T18:29:18+00:00",
+    "updated_at": "2024-05-25T18:29:18+00:00",
+    "changelog": {
+        "id": 246,
+        "release_id": 239,
+        "description": null,
+        "changes": [
+            {
+                "release_changelog_id": 246,
+                "release_changelog_category_id": 5,
+                "ticket_id": 2388,
+                "change": "Fixed search page not working before switching tabs, fixed the dungeon text moving around when selecting one and finally the dungeons listed in the URL now get restored properly."
+            }
+        ]
+    }
+}

--- a/resources/assets/css/custom.css
+++ b/resources/assets/css/custom.css
@@ -150,7 +150,8 @@ ul.light-slider {
 
 /** Prevents the title from jumping when it gets selected */
 .discover .grid_dungeon.selectable.selected h5 {
-    padding-right: 0.25rem !important
+    width: calc(100% - 0.75rem); /* 0.375 x2 for the padding */
+    top: calc(15% - 0.125rem); /* 0.125 for the red border, but just one side since it's the top */
 }
 
 
@@ -165,7 +166,7 @@ ul.light-slider {
 
 .discover .card-img-caption .card-text {
     text-align: center;
-    width: calc(100% - 1rem);
+    width: calc(100% - 1rem); /* overcome the padding - this makes it fit exactly */
     top: 15%;
     position: absolute;
     z-index: 1;

--- a/resources/assets/js/custom/inline/base/searchinlinebase.js
+++ b/resources/assets/js/custom/inline/base/searchinlinebase.js
@@ -27,10 +27,13 @@ class SearchInlineBase extends InlineCode {
 
         // Restore URL -> filters values
         for (let key in queryParams) {
-            if (queryParams.hasOwnProperty(key) && this.filters.hasOwnProperty(key)) {
+            let filtersKey = key.replace('[]', '');
+            console.log(`Attempting to restore value for ${key} (${filtersKey})`);
+            if (queryParams.hasOwnProperty(key) && this.filters.hasOwnProperty(filtersKey)) {
+                console.log(`Restoring value for ${key}`);
                 let value = queryParams[key];
 
-                this.filters[key].setValue(value);
+                this.filters[filtersKey].setValue(value);
             }
         }
     }

--- a/resources/assets/js/custom/inline/base/searchinlinebase.js
+++ b/resources/assets/js/custom/inline/base/searchinlinebase.js
@@ -28,9 +28,7 @@ class SearchInlineBase extends InlineCode {
         // Restore URL -> filters values
         for (let key in queryParams) {
             let filtersKey = key.replace('[]', '');
-            console.log(`Attempting to restore value for ${key} (${filtersKey})`);
             if (queryParams.hasOwnProperty(key) && this.filters.hasOwnProperty(filtersKey)) {
-                console.log(`Restoring value for ${key}`);
                 let value = queryParams[key];
 
                 this.filters[filtersKey].setValue(value);

--- a/resources/assets/js/custom/inline/dungeonroute/discover/search.js
+++ b/resources/assets/js/custom/inline/dungeonroute/discover/search.js
@@ -48,7 +48,9 @@ class DungeonrouteDiscoverSearch extends SearchInlineBase {
         // If we have seasons and should select one
         if (this.options.gameVersion.has_seasons && this.filters.expansion.getValue() === '') {
             // If we didn't have an expansion from the URL, select the first tab instead
-            let selectedSeason = this.filters.season.getValue() ?? this.options.nextSeason ?? this.options.currentSeason;
+            let selectedSeason = this.filters.season.getValue() !== ''
+                ? this.filters.season.getValue()
+                : this.options.nextSeason ?? this.options.currentSeason;
 
             $(`#season-${selectedSeason}-grid-tab`).tab('show');
             this._selectSeason(selectedSeason);
@@ -76,6 +78,8 @@ class DungeonrouteDiscoverSearch extends SearchInlineBase {
      * @private
      */
     _selectExpansion(expansion) {
+        console.log(`Selecting expansion ${expansion}`);
+
         if (expansion !== null) {
             $(`#search_dungeon .grid_dungeon`).removeClass('selectable');
             $(`#${expansion}-grid-content .grid_dungeon`).addClass('selectable');
@@ -95,6 +99,8 @@ class DungeonrouteDiscoverSearch extends SearchInlineBase {
      * @private
      */
     _selectSeason(season) {
+        console.log(`Selecting season ${season}`);
+
         if (season !== null) {
             $(`#search_dungeon .grid_dungeon`).removeClass('selectable');
             $(`#season-${season}-grid-content .grid_dungeon`).addClass('selectable');

--- a/resources/assets/js/custom/inline/dungeonroute/discover/search.js
+++ b/resources/assets/js/custom/inline/dungeonroute/discover/search.js
@@ -78,8 +78,6 @@ class DungeonrouteDiscoverSearch extends SearchInlineBase {
      * @private
      */
     _selectExpansion(expansion) {
-        console.log(`Selecting expansion ${expansion}`);
-
         if (expansion !== null) {
             $(`#search_dungeon .grid_dungeon`).removeClass('selectable');
             $(`#${expansion}-grid-content .grid_dungeon`).addClass('selectable');
@@ -99,8 +97,6 @@ class DungeonrouteDiscoverSearch extends SearchInlineBase {
      * @private
      */
     _selectSeason(season) {
-        console.log(`Selecting season ${season}`);
-
         if (season !== null) {
             $(`#search_dungeon .grid_dungeon`).removeClass('selectable');
             $(`#season-${season}-grid-content .grid_dungeon`).addClass('selectable');


### PR DESCRIPTION
Bugfixes:
  * #2388 Fixed search page not working before switching tabs, fixed the dungeon text moving around when selecting one and finally the dungeons listed in the URL now get restored properly.