### PR TITLE
#1769 Featured creators rail on the reworked per-dungeon route page

### DIFF
--- a/.claude/skills/blade-expert/SKILL.md
+++ b/.claude/skills/blade-expert/SKILL.md
@@ -47,3 +47,31 @@ the site.
 
 To understand how to write JavaScript for blade files, include the `javascript-in-blade-files` skill in your prompt and follow the instructions there.
 
+
+## Theming: never use the `bg-body-*` / `text-bg-*` Bootstrap utilities
+
+This site ships **one class-scoped stylesheet per bootswatch theme** (`<html class="theme darkly">`,
+switched server-side from the user's `theme` column) rather than using Bootstrap 5.3's
+`data-bs-theme` attribute. Bootswatch therefore never overrides the `--bs-*-bg` custom properties:
+under **darkly** and **vapor**, `--bs-tertiary-bg` is still its light default `#f8f9fa`.
+
+So `class="bg-body-tertiary"` renders a **white panel with white text** on the dark themes — it
+looks fine in a light theme and is invisible in a dark one. Found in #1772 by screenshotting the
+page; no test catches it.
+
+- **For panels/cards**: use a Bootstrap `.card` (`<div class="card"><div class="card-body">`), which
+  bootswatch *does* theme per stylesheet.
+- **For borders/text**: `border`, `text-body-secondary` and `text-muted` are safe —
+  `--bs-secondary-color` *is* themed.
+- **For icon buttons on a themed surface**: inherit `currentColor` rather than picking
+  `btn-outline-secondary`. `$secondary` is a dark grey under darkly/vapor (invisible on a dark card)
+  and picking a light variant instead fails the same way under lux. See
+  `resources/assets/css/sections/creator-profile.css`.
+
+**Always verify a new surface under both a dark and a light theme.** Because every theme lives in
+the one stylesheet, swapping the `html` class is a faithful preview and needs no session change:
+
+```sh
+docker compose exec -T -e PRE_EVAL='document.documentElement.className = "theme lux"' app \
+    sh -c 'cd /var/www && node .chrome-tmp/authshot.js ...'
+```

--- a/app/Features/CreatorProfiles.php
+++ b/app/Features/CreatorProfiles.php
@@ -8,7 +8,7 @@ use App\Models\User;
 
 /**
  * Gates the creator podium: the revamped public profile (bio, socials, pinned routes), the creator
- * directory, and the featured-creators row on the discover landing page.
+ * directory, and the featured-creators strip on the per-dungeon route page.
  *
  * While in development this resolves only for admins and the internal team, so the work can merge
  * dark. Opening it to the public is a one-line change here - drop the role check and return true

--- a/app/Features/CreatorProfiles.php
+++ b/app/Features/CreatorProfiles.php
@@ -8,7 +8,7 @@ use App\Models\User;
 
 /**
  * Gates the creator podium: the revamped public profile (bio, socials, pinned routes), the creator
- * directory, and the featured-creators strip on the per-dungeon route page.
+ * directory, and the featured-creators rail on the per-dungeon route page.
  *
  * While in development this resolves only for admins and the internal team, so the work can merge
  * dark. Opening it to the public is a one-line change here - drop the role check and return true

--- a/app/Http/View/Composers/FeaturedCreatorsComposer.php
+++ b/app/Http/View/Composers/FeaturedCreatorsComposer.php
@@ -8,7 +8,7 @@ use Illuminate\View\View;
 /**
  * Binds the featured creators onto the partial itself rather than onto the page including it.
  *
- * The strip is a self-contained section that any of the discover surfaces may pick up, and the
+ * The rail is a self-contained section that any of the discover surfaces may pick up, and the
  * controllers behind them already assemble a lot. Composing the partial means adding it to another
  * page is a single @include that can never silently render empty because someone forgot to pass the
  * data - the same reason DiscoverSearchComposer and DiscoverAffixGroupComposer exist.

--- a/app/Http/View/Composers/FeaturedCreatorsComposer.php
+++ b/app/Http/View/Composers/FeaturedCreatorsComposer.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\View\Composers;
+
+use App\Service\Creator\CreatorDirectoryServiceInterface;
+use Illuminate\View\View;
+
+/**
+ * Binds the featured creators onto the partial itself rather than onto the discover landing page.
+ *
+ * Three different controller methods render dungeonroute.discover.discover, so passing the data
+ * from each one would have to be repeated three times and would silently break the day a fourth is
+ * added. Composing the partial keeps the landing page's change to a single @include.
+ */
+readonly class FeaturedCreatorsComposer implements ViewComposerInterface
+{
+    public function __construct(
+        private CreatorDirectoryServiceInterface $creatorDirectoryService,
+    ) {
+    }
+
+    public function compose(View $view): void
+    {
+        $view->with('featuredCreators', $this->creatorDirectoryService->getFeaturedCreators());
+    }
+}

--- a/app/Http/View/Composers/FeaturedCreatorsComposer.php
+++ b/app/Http/View/Composers/FeaturedCreatorsComposer.php
@@ -6,11 +6,12 @@ use App\Service\Creator\CreatorDirectoryServiceInterface;
 use Illuminate\View\View;
 
 /**
- * Binds the featured creators onto the partial itself rather than onto the discover landing page.
+ * Binds the featured creators onto the partial itself rather than onto the page including it.
  *
- * Three different controller methods render dungeonroute.discover.discover, so passing the data
- * from each one would have to be repeated three times and would silently break the day a fourth is
- * added. Composing the partial keeps the landing page's change to a single @include.
+ * The strip is a self-contained section that any of the discover surfaces may pick up, and the
+ * controllers behind them already assemble a lot. Composing the partial means adding it to another
+ * page is a single @include that can never silently render empty because someone forgot to pass the
+ * data - the same reason DiscoverSearchComposer and DiscoverAffixGroupComposer exist.
  */
 readonly class FeaturedCreatorsComposer implements ViewComposerInterface
 {

--- a/app/Providers/KeystoneGuruServiceProvider.php
+++ b/app/Providers/KeystoneGuruServiceProvider.php
@@ -18,6 +18,7 @@ use App\Http\View\Composers\DungeonGridTabsComposer;
 use App\Http\View\Composers\DungeonSelectComposer;
 use App\Http\View\Composers\DungeonStartSelectComposer;
 use App\Http\View\Composers\EmbedComposer;
+use App\Http\View\Composers\FeaturedCreatorsComposer;
 use App\Http\View\Composers\GameVersionsNavComposer;
 use App\Http\View\Composers\GlobalComposer;
 use App\Http\View\Composers\HeaderComposer;
@@ -387,6 +388,8 @@ class KeystoneGuruServiceProvider extends ServiceProvider
 
         // Dungeon grid view
         view()->composer('dungeonroute.discover.search', DiscoverSearchComposer::class);
+
+        view()->composer('creator.featured', FeaturedCreatorsComposer::class);
 
         view()->composer('common.dungeonroute.create.dungeondifficultyselect', DungeonDifficultySelectComposer::class);
 

--- a/app/Providers/KeystoneGuruServiceProvider.php
+++ b/app/Providers/KeystoneGuruServiceProvider.php
@@ -17,6 +17,7 @@ use App\Http\View\Composers\DungeonGridTabsComposer;
 use App\Http\View\Composers\DungeonSelectComposer;
 use App\Http\View\Composers\DungeonStartSelectComposer;
 use App\Http\View\Composers\EmbedComposer;
+use App\Http\View\Composers\FeaturedCreatorsComposer;
 use App\Http\View\Composers\GameVersionsNavComposer;
 use App\Http\View\Composers\GlobalComposer;
 use App\Http\View\Composers\HeaderComposer;
@@ -357,6 +358,8 @@ class KeystoneGuruServiceProvider extends ServiceProvider
 
         // Dungeon grid view
         view()->composer('dungeonroute.discover.search', DiscoverSearchComposer::class);
+
+        view()->composer('creator.featured', FeaturedCreatorsComposer::class);
 
         view()->composer('common.dungeonroute.create.dungeondifficultyselect', DungeonDifficultySelectComposer::class);
 

--- a/app/Service/Creator/CreatorDirectoryService.php
+++ b/app/Service/Creator/CreatorDirectoryService.php
@@ -4,14 +4,17 @@ namespace App\Service\Creator;
 
 use App\Models\User;
 use App\Repositories\Interfaces\UserRepositoryInterface;
+use App\Service\Cache\CacheServiceInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
 class CreatorDirectoryService implements CreatorDirectoryServiceInterface
 {
-    public function __construct(private readonly UserRepositoryInterface $userRepository)
-    {
+    public function __construct(
+        private readonly UserRepositoryInterface $userRepository,
+        private readonly CacheServiceInterface   $cacheService,
+    ) {
     }
 
     /** @return LengthAwarePaginator<int, User> */
@@ -32,13 +35,28 @@ class CreatorDirectoryService implements CreatorDirectoryServiceInterface
             ->withQueryString();
     }
 
-    /** @return Collection<int, User> */
+    /**
+     * Cached, unlike paginateCreators(): buildListedCreatorsQuery() derives its published route
+     * counts with a GROUP BY over the whole dungeon_routes table, which materialises in full before
+     * the LIMIT can take six rows off it. The strip renders on the per-dungeon route page - one of
+     * the busiest on the site - and, sitting below the paginator, on every page of results.
+     *
+     * The result does not vary by viewer, dungeon or page, so there is nothing to key on and no
+     * invalidation question: it is a site-wide list that goes stale gracefully within the TTL.
+     * CacheService::remember() is a passthrough while caching is disabled (development, tests).
+     *
+     * @return Collection<int, User>
+     */
     public function getFeaturedCreators(?int $limit = null): Collection
     {
         $limit ??= (int)config('keystoneguru.creators.featured_count');
 
-        return $this->userRepository->buildListedCreatorsQuery()
-            ->limit($limit)
-            ->get();
+        return $this->cacheService->remember(
+            sprintf('creators:featured:%d', $limit),
+            fn(): Collection => $this->userRepository->buildListedCreatorsQuery()
+                ->limit($limit)
+                ->get(),
+            config('keystoneguru.creators.featured_ttl'),
+        );
     }
 }

--- a/app/Service/Creator/CreatorDirectoryService.php
+++ b/app/Service/Creator/CreatorDirectoryService.php
@@ -38,8 +38,9 @@ class CreatorDirectoryService implements CreatorDirectoryServiceInterface
     /**
      * Cached, unlike paginateCreators(): buildListedCreatorsQuery() derives its published route
      * counts with a GROUP BY over the whole dungeon_routes table, which materialises in full before
-     * the LIMIT can take six rows off it. The strip renders on the per-dungeon route page - one of
-     * the busiest on the site - and, sitting below the paginator, on every page of results.
+     * the LIMIT can take six rows off it. The rail renders on the per-dungeon route page - one of
+     * the busiest on the site - and, unlike the hero band, on every page of results, not just the
+     * first.
      *
      * The result does not vary by viewer, dungeon or page, so there is nothing to key on and no
      * invalidation question: it is a site-wide list that goes stale gracefully within the TTL.

--- a/app/Service/Creator/CreatorDirectoryService.php
+++ b/app/Service/Creator/CreatorDirectoryService.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Repositories\Interfaces\UserRepositoryInterface;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 
 class CreatorDirectoryService implements CreatorDirectoryServiceInterface
 {
@@ -29,5 +30,15 @@ class CreatorDirectoryService implements CreatorDirectoryServiceInterface
             )
             ->paginate($perPage)
             ->withQueryString();
+    }
+
+    /** @return Collection<int, User> */
+    public function getFeaturedCreators(?int $limit = null): Collection
+    {
+        $limit ??= (int)config('keystoneguru.creators.featured_count');
+
+        return $this->userRepository->buildListedCreatorsQuery()
+            ->limit($limit)
+            ->get();
     }
 }

--- a/app/Service/Creator/CreatorDirectoryServiceInterface.php
+++ b/app/Service/Creator/CreatorDirectoryServiceInterface.php
@@ -18,7 +18,7 @@ interface CreatorDirectoryServiceInterface
     public function paginateCreators(?string $search = null, ?int $perPage = null): LengthAwarePaginator;
 
     /**
-     * The creators to surface in the featured strip on the per-dungeon route page.
+     * The creators to surface in the featured rail on the per-dungeon route page.
      *
      * @return Collection<int, User>
      */

--- a/app/Service/Creator/CreatorDirectoryServiceInterface.php
+++ b/app/Service/Creator/CreatorDirectoryServiceInterface.php
@@ -18,7 +18,7 @@ interface CreatorDirectoryServiceInterface
     public function paginateCreators(?string $search = null, ?int $perPage = null): LengthAwarePaginator;
 
     /**
-     * The creators to surface on the discover landing page.
+     * The creators to surface in the featured strip on the per-dungeon route page.
      *
      * @return Collection<int, User>
      */

--- a/app/Service/Creator/CreatorDirectoryServiceInterface.php
+++ b/app/Service/Creator/CreatorDirectoryServiceInterface.php
@@ -4,6 +4,7 @@ namespace App\Service\Creator;
 
 use App\Models\User;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Collection;
 
 interface CreatorDirectoryServiceInterface
 {
@@ -15,4 +16,11 @@ interface CreatorDirectoryServiceInterface
      * @return LengthAwarePaginator<int, User>
      */
     public function paginateCreators(?string $search = null, ?int $perPage = null): LengthAwarePaginator;
+
+    /**
+     * The creators to surface on the discover landing page.
+     *
+     * @return Collection<int, User>
+     */
+    public function getFeaturedCreators(?int $limit = null): Collection;
 }

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -271,7 +271,7 @@ return [
         /** How many creators to show per page of the directory */
         'per_page' => 24,
 
-        /** How many creators to feature in the rail - four fit one clean row at its 70rem measure */
+        /** How many creators to feature in the rail - four is what fits its 70rem measure without the shelf needing to scroll on a desktop */
         'featured_count' => 4,
 
         /** The rail is a site-wide list off a heavy GROUP BY, so it may go this stale - see getFeaturedCreators() */

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -281,6 +281,9 @@ return [
 
         /** How many creators to show per page of the directory */
         'per_page' => 24,
+
+        /** How many creators to feature on the discover landing page */
+        'featured_count' => 8,
     ],
 
     /**

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -271,7 +271,7 @@ return [
         /** How many creators to show per page of the directory */
         'per_page' => 24,
 
-        /** How many creators to feature on the discover landing page */
+        /** How many creators to feature in the strip on the per-dungeon route page */
         'featured_count' => 6,
     ],
 

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -283,7 +283,7 @@ return [
         'per_page' => 24,
 
         /** How many creators to feature on the discover landing page */
-        'featured_count' => 8,
+        'featured_count' => 6,
     ],
 
     /**

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -271,10 +271,10 @@ return [
         /** How many creators to show per page of the directory */
         'per_page' => 24,
 
-        /** How many creators to feature in the strip on the per-dungeon route page */
+        /** How many creators to feature in the rail on the per-dungeon route page */
         'featured_count' => 6,
 
-        /** The strip is a site-wide list off a heavy GROUP BY, so it may go this stale - see getFeaturedCreators() */
+        /** The rail is a site-wide list off a heavy GROUP BY, so it may go this stale - see getFeaturedCreators() */
         'featured_ttl' => '1 hour',
     ],
 

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -272,7 +272,7 @@ return [
         'per_page' => 24,
 
         /** How many creators to feature on the discover landing page */
-        'featured_count' => 8,
+        'featured_count' => 6,
     ],
 
     /**

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -273,6 +273,9 @@ return [
 
         /** How many creators to feature in the strip on the per-dungeon route page */
         'featured_count' => 6,
+
+        /** The strip is a site-wide list off a heavy GROUP BY, so it may go this stale - see getFeaturedCreators() */
+        'featured_ttl' => '1 hour',
     ],
 
     /**

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -270,6 +270,9 @@ return [
 
         /** How many creators to show per page of the directory */
         'per_page' => 24,
+
+        /** How many creators to feature on the discover landing page */
+        'featured_count' => 8,
     ],
 
     /**

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -271,8 +271,8 @@ return [
         /** How many creators to show per page of the directory */
         'per_page' => 24,
 
-        /** How many creators to feature in the rail on the per-dungeon route page */
-        'featured_count' => 6,
+        /** How many creators to feature in the rail - four fit one clean row at its 70rem measure */
+        'featured_count' => 4,
 
         /** The rail is a site-wide list off a heavy GROUP BY, so it may go this stale - see getFeaturedCreators() */
         'featured_ttl' => '1 hour',

--- a/lang/en_US/view_creator.php
+++ b/lang/en_US/view_creator.php
@@ -11,6 +11,10 @@ return [
         'empty'              => 'There are no listed creators yet.',
         'empty_for_search'   => 'No creators found matching ":search".',
     ],
+    'featured' => [
+        'title'   => 'Featured creators',
+        'see_all' => 'See all creators',
+    ],
     'card' => [
         'route_count' => '{0} No published routes|{1} :count published route|[2,*] :count published routes',
     ],

--- a/lang/en_US/view_creator.php
+++ b/lang/en_US/view_creator.php
@@ -14,6 +14,8 @@ return [
     'featured' => [
         'title'   => 'Featured creators',
         'see_all' => 'See all creators',
+        /** Tooltip on a rail entry - it carries the name because the name itself may be clipped to an ellipsis */
+        'entry_title' => ':name - :routes',
     ],
     'card' => [
         'route_count' => '{0} No published routes|{1} :count published route|[2,*] :count published routes',

--- a/resources/assets/css/sections/creator-featured.css
+++ b/resources/assets/css/sections/creator-featured.css
@@ -90,9 +90,16 @@
     color: inherit;
 }
 
+/*
+ * An inset ring, not an outset one. The entries live in a scroll container now, and an outline
+ * contributes nothing to the scrollable overflow region - so a positive offset is simply clipped:
+ * the top 4px on every entry (overflow-x: auto makes the block axis a scrollport too), and the
+ * left edge of the first entry at scroll position 0. A negative offset draws the ring just inside
+ * the entry's own border box, where nothing can crop it, at any width or scroll position.
+ */
 .discover_creator_entry:focus-visible {
     outline: 2px solid var(--theme-btn-accent);
-    outline-offset: 2px;
+    outline-offset: -2px;
 }
 
 .discover_creator_avatar,
@@ -145,9 +152,9 @@
     line-height: 1.25;
 }
 
-/* One line each: the rail wraps between entries, never inside one. A name clipped here stays
-   readable via the entry's title attribute, which carries the full name alongside the published
-   route count - keep those two in step (see creator/featured.blade.php). */
+/* One line each: an entry is always exactly two lines tall, whatever the name's length. Text clipped
+   here stays readable via the entry's title attribute, which carries the full name alongside the
+   published route count - keep those two in step (see creator/featured.blade.php). */
 .discover_creator_name,
 .discover_creator_count {
     overflow: hidden;

--- a/resources/assets/css/sections/creator-featured.css
+++ b/resources/assets/css/sections/creator-featured.css
@@ -3,10 +3,17 @@
  * band.
  *
  * A rail rather than a section, because it opens the page: a grid of tiles here would push the
- * routes the visitor came for below the fold. One line of avatar-plus-name reads as a caption above
- * the hero band instead of a second section competing with it. It borrows the leaderboard's
- * vocabulary - page-background rows, neutral-gray hairlines, a gray hover wash, the same 70rem
- * measure - so the whole page reads on one system.
+ * routes the visitor came for below the fold. It borrows the leaderboard's vocabulary - neutral-gray
+ * hairlines and washes, the same 70rem measure - so the whole page reads on one system.
+ *
+ * Two earlier passes made it read as a list of tags rather than as people, and both causes are
+ * worth remembering because neither is about size:
+ *   - the label sat inline ahead of the entries, and "label: item item item" on one line is the
+ *     grammar of a tag list. It now has its own line.
+ *   - each entry carried a single short string. An entry now carries the creator's published route
+ *     count under their name, which is both the evidence that makes them worth a click and the
+ *     thing that makes the entry read as a person rather than a label.
+ * Entries also have a resting surface, not just a hover one, so they are objects at rest.
  *
  * Colour comes from the theme. Do not reach for bg-body-* utilities: this site ships one
  * class-scoped stylesheet per bootswatch theme rather than using data-bs-theme, so --bs-tertiary-bg
@@ -15,29 +22,61 @@
 
 /* Matches .dungeonroute_leaderboard and .discover_pagination so the three stack on one measure */
 .discover_creator_rail {
-    display: flex;
     max-width: 70rem;
     margin-left: auto;
     margin-right: auto;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 0.25rem 0.5rem;
+}
+
+.discover_creator_rail_heading {
+    margin-bottom: 0.5rem;
+    text-align: center;
 }
 
 .discover_creator_rail_label {
-    margin-right: 0.25rem;
     font-weight: 600;
     text-decoration: none;
-    white-space: nowrap;
+}
+
+/*
+ * A shelf that scrolls rather than a row that wraps, at every width - not a phone special case.
+ * Wrapping put an orphan on the second line at most widths (3+1 at 1280px, 1-per-row on a phone),
+ * which reads as accidental and costs the hero band its place on the first screen. The rail's usable
+ * width is not even monotonic across breakpoints - `discover col-xl-8` only applies from 1200px up,
+ * so 1199px is *wider* than 1280px - so chasing it with breakpoints does not converge.
+ *
+ * With room, `safe center` centres the entries and no scrollbar appears; without, it scrolls with
+ * the next entry peeking in as the affordance. `flex-start` first: browsers without `safe` keep it,
+ * because plain `center` plus overflow makes the leading entries unreachable. The overflow stays
+ * inside this container - the page body itself never scrolls horizontally.
+ */
+.discover_creator_rail_entries {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+    justify-content: flex-start;
+    justify-content: safe center;
+    gap: 0.5rem;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    /* A hairline in the same neutral gray as the rest of the rail; the platform default is a heavy
+       bar right under a 94px caption. Both values are theme-agnostic on purpose. */
+    scrollbar-width: thin;
+    scrollbar-color: rgba(128, 128, 128, 0.5) transparent;
+    scroll-snap-type: x proximity;
 }
 
 .discover_creator_entry {
     display: inline-flex;
+    flex: 0 0 auto;
     align-items: center;
     max-width: 100%;
-    padding: 0.25rem 0.625rem 0.25rem 0.25rem;
-    border: 1px solid transparent;
+    scroll-snap-align: start;
+    padding: 0.375rem 0.75rem 0.375rem 0.375rem;
+    /* A resting surface, not only a hover one: without it the entries float as loose text on the
+       wallpaper and read as metadata. Neutral gray rather than --theme-bg-card so the dungeon art
+       still shows through, the way the breadcrumb bar directly above does. */
+    background-color: rgba(128, 128, 128, 0.12);
+    border: 1px solid rgba(128, 128, 128, 0.28);
     border-radius: var(--bs-border-radius);
     color: inherit;
     text-decoration: none;
@@ -46,8 +85,8 @@
 
 .discover_creator_entry:hover,
 .discover_creator_entry:focus-visible {
-    background-color: rgba(128, 128, 128, 0.1);
-    border-color: rgba(128, 128, 128, 0.28);
+    background-color: rgba(128, 128, 128, 0.22);
+    border-color: rgba(128, 128, 128, 0.5);
     color: inherit;
 }
 
@@ -59,9 +98,9 @@
 .discover_creator_avatar,
 .discover_creator_initials {
     flex: 0 0 auto;
-    width: 32px;
-    height: 32px;
-    margin-right: 0.5rem;
+    width: 44px;
+    height: 44px;
+    margin-right: 0.625rem;
     border: 2px solid rgba(128, 128, 128, 0.35);
     border-radius: 50%;
     object-fit: cover;
@@ -93,46 +132,37 @@
     justify-content: center;
     background-color: rgba(128, 128, 128, 0.25);
     color: var(--theme-text-contrast);
-    font-size: 0.75rem;
+    font-size: 0.9375rem;
     font-weight: 600;
     line-height: 1;
 }
 
-/* One line: the rail wraps between entries, never inside a name. A name clipped here stays readable
-   via the entry's title attribute, which carries the full name alongside the published route count -
-   keep those two in step (see creator/featured.blade.php). */
-.discover_creator_name {
+.discover_creator_text {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    justify-content: center;
+    line-height: 1.25;
+}
+
+/* One line each: the rail wraps between entries, never inside one. A name clipped here stays
+   readable via the entry's title attribute, which carries the full name alongside the published
+   route count - keep those two in step (see creator/featured.blade.php). */
+.discover_creator_name,
+.discover_creator_count {
     overflow: hidden;
-    color: var(--theme-text-contrast);
-    font-weight: 600;
     text-overflow: ellipsis;
     white-space: nowrap;
 }
 
-@media (max-width: 575.98px) {
-    /* Phones fit two entries per line; a full-width label above them keeps the first line from
-       being label-plus-one-lonely-creator. */
-    .discover_creator_rail_label {
-        flex-basis: 100%;
-        margin-right: 0;
-        text-align: center;
-    }
+.discover_creator_name {
+    max-width: 10rem;
+    color: var(--theme-text-contrast);
+    font-weight: 600;
+}
 
-    /* Narrow enough that two always share a line, rather than a long name orphaning one per row */
-    .discover_creator_name {
-        max-width: 6.5rem;
-    }
-
-    /*
-     * Trim the rail to four on phones. All six wrap to four lines here and push the hero band - the
-     * routes the visitor actually came for - most of the way off the first screen; the whole point
-     * of opening with a rail instead of a grid is that it stays a caption. The label still links to
-     * the full directory. Same call the leaderboard already makes with its rating and favourites
-     * columns (see discover.css).
-     */
-    .discover_creator_entry:nth-child(n+6) {
-        display: none;
-    }
+.discover_creator_count {
+    font-size: 0.8125rem;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/assets/css/sections/creator-featured.css
+++ b/resources/assets/css/sections/creator-featured.css
@@ -98,8 +98,9 @@
     line-height: 1;
 }
 
-/* One line: the rail wraps between entries, never inside a name. The full name stays reachable via
-   the entry's title attribute, which also carries the published route count. */
+/* One line: the rail wraps between entries, never inside a name. A name clipped here stays readable
+   via the entry's title attribute, which carries the full name alongside the published route count -
+   keep those two in step (see creator/featured.blade.php). */
 .discover_creator_name {
     overflow: hidden;
     color: var(--theme-text-contrast);

--- a/resources/assets/css/sections/creator-featured.css
+++ b/resources/assets/css/sections/creator-featured.css
@@ -1,11 +1,12 @@
 /**
- * Featured creators strip - the closing section of the reworked per-dungeon route page.
+ * Featured creators rail - the opening line of the reworked per-dungeon route page, above the hero
+ * band.
  *
- * A deliberately quieter treatment than the creator directory's .card tiles: the page descends from
- * the cinematic hero band, through the dense ranked leaderboard, to this. It therefore borrows the
- * leaderboard's vocabulary (page-background rows, neutral-gray hairlines, a gray hover wash, the
- * same 70rem measure) instead of stacking another grid of cards under it. Same creator, different
- * skin - exactly as a route already renders as a poster, a hero and a leaderboard row.
+ * A rail rather than a section, because it opens the page: a grid of tiles here would push the
+ * routes the visitor came for below the fold. One line of avatar-plus-name reads as a caption above
+ * the hero band instead of a second section competing with it. It borrows the leaderboard's
+ * vocabulary - page-background rows, neutral-gray hairlines, a gray hover wash, the same 70rem
+ * measure - so the whole page reads on one system.
  *
  * Colour comes from the theme. Do not reach for bg-body-* utilities: this site ships one
  * class-scoped stylesheet per bootswatch theme rather than using data-bs-theme, so --bs-tertiary-bg
@@ -13,19 +14,32 @@
  */
 
 /* Matches .dungeonroute_leaderboard and .discover_pagination so the three stack on one measure */
-.discover_creator_strip {
+.discover_creator_rail {
+    display: flex;
     max-width: 70rem;
     margin-left: auto;
     margin-right: auto;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem 0.5rem;
+}
+
+.discover_creator_rail_label {
+    margin-right: 0.25rem;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
 }
 
 .discover_creator_entry {
-    display: block;
-    padding: 0.75rem 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    padding: 0.25rem 0.625rem 0.25rem 0.25rem;
     border: 1px solid transparent;
     border-radius: var(--bs-border-radius);
     color: inherit;
-    text-align: center;
     text-decoration: none;
     transition: background-color 0.12s ease, border-color 0.12s ease;
 }
@@ -44,17 +58,17 @@
 
 .discover_creator_avatar,
 .discover_creator_initials {
-    width: 56px;
-    height: 56px;
-    margin-left: auto;
-    margin-right: auto;
+    flex: 0 0 auto;
+    width: 32px;
+    height: 32px;
+    margin-right: 0.5rem;
     border: 2px solid rgba(128, 128, 128, 0.35);
     border-radius: 50%;
     object-fit: cover;
     transition: border-color 0.12s ease;
 }
 
-/* The one accent moment in the section: the ring picks up the theme's "go" colour on hover */
+/* The one accent moment in the rail: the ring picks up the theme's "go" colour on hover */
 .discover_creator_entry:hover .discover_creator_avatar,
 .discover_creator_entry:focus-visible .discover_creator_avatar,
 .discover_creator_entry:hover .discover_creator_initials,
@@ -74,25 +88,50 @@
  * moment next to the hover ring, and reads as low-contrast lettering on the neutral disc.
  */
 .discover_creator_initials {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     background-color: rgba(128, 128, 128, 0.25);
     color: var(--theme-text-contrast);
-    font-size: 1.25rem;
+    font-size: 0.75rem;
     font-weight: 600;
     line-height: 1;
 }
 
-/* One line: six names across 70rem have no room to wrap, and the title attribute keeps the full
-   name reachable when it is truncated. */
+/* One line: the rail wraps between entries, never inside a name. The full name stays reachable via
+   the entry's title attribute, which also carries the published route count. */
 .discover_creator_name {
-    margin-top: 0.5rem;
     overflow: hidden;
     color: var(--theme-text-contrast);
     font-weight: 600;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+@media (max-width: 575.98px) {
+    /* Phones fit two entries per line; a full-width label above them keeps the first line from
+       being label-plus-one-lonely-creator. */
+    .discover_creator_rail_label {
+        flex-basis: 100%;
+        margin-right: 0;
+        text-align: center;
+    }
+
+    /* Narrow enough that two always share a line, rather than a long name orphaning one per row */
+    .discover_creator_name {
+        max-width: 6.5rem;
+    }
+
+    /*
+     * Trim the rail to four on phones. All six wrap to four lines here and push the hero band - the
+     * routes the visitor actually came for - most of the way off the first screen; the whole point
+     * of opening with a rail instead of a grid is that it stays a caption. The label still links to
+     * the full directory. Same call the leaderboard already makes with its rating and favourites
+     * columns (see discover.css).
+     */
+    .discover_creator_entry:nth-child(n+6) {
+        display: none;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/assets/css/sections/creator-featured.css
+++ b/resources/assets/css/sections/creator-featured.css
@@ -1,0 +1,104 @@
+/**
+ * Featured creators strip - the closing section of the reworked per-dungeon route page.
+ *
+ * A deliberately quieter treatment than the creator directory's .card tiles: the page descends from
+ * the cinematic hero band, through the dense ranked leaderboard, to this. It therefore borrows the
+ * leaderboard's vocabulary (page-background rows, neutral-gray hairlines, a gray hover wash, the
+ * same 70rem measure) instead of stacking another grid of cards under it. Same creator, different
+ * skin - exactly as a route already renders as a poster, a hero and a leaderboard row.
+ *
+ * Colour comes from the theme. Do not reach for bg-body-* utilities: this site ships one
+ * class-scoped stylesheet per bootswatch theme rather than using data-bs-theme, so --bs-tertiary-bg
+ * stays at its light default and renders an unreadable panel under darkly/vapor.
+ */
+
+/* Matches .dungeonroute_leaderboard and .discover_pagination so the three stack on one measure */
+.discover_creator_strip {
+    max-width: 70rem;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.discover_creator_entry {
+    display: block;
+    padding: 0.75rem 0.5rem;
+    border: 1px solid transparent;
+    border-radius: var(--bs-border-radius);
+    color: inherit;
+    text-align: center;
+    text-decoration: none;
+    transition: background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.discover_creator_entry:hover,
+.discover_creator_entry:focus-visible {
+    background-color: rgba(128, 128, 128, 0.1);
+    border-color: rgba(128, 128, 128, 0.28);
+    color: inherit;
+}
+
+.discover_creator_entry:focus-visible {
+    outline: 2px solid var(--theme-btn-accent);
+    outline-offset: 2px;
+}
+
+.discover_creator_avatar,
+.discover_creator_initials {
+    width: 56px;
+    height: 56px;
+    margin-left: auto;
+    margin-right: auto;
+    border: 2px solid rgba(128, 128, 128, 0.35);
+    border-radius: 50%;
+    object-fit: cover;
+    transition: border-color 0.12s ease;
+}
+
+/* The one accent moment in the section: the ring picks up the theme's "go" colour on hover */
+.discover_creator_entry:hover .discover_creator_avatar,
+.discover_creator_entry:focus-visible .discover_creator_avatar,
+.discover_creator_entry:hover .discover_creator_initials,
+.discover_creator_entry:focus-visible .discover_creator_initials {
+    border-color: var(--theme-btn-accent);
+}
+
+/*
+ * Deliberately not bg-secondary: bootswatch's $secondary is a dark grey under darkly and vapor but
+ * a light grey under lux, so the white text the directory pairs with it is unreadable on one of
+ * them. A neutral gray wash with body text tracks every theme instead - the same idiom as the
+ * leaderboard thumbnail's always-on backdrop.
+ *
+ * The colour is stated, not inherited: each theme's `.theme.<name> a` rule outweighs a single class
+ * on the entry, so an inherited colour resolves to the theme's *link* colour and paints the
+ * initials the accent (green under darkly, purple under vapor). That would put a second accent
+ * moment next to the hover ring, and reads as low-contrast lettering on the neutral disc.
+ */
+.discover_creator_initials {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(128, 128, 128, 0.25);
+    color: var(--theme-text-contrast);
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1;
+}
+
+/* One line: six names across 70rem have no room to wrap, and the title attribute keeps the full
+   name reachable when it is truncated. */
+.discover_creator_name {
+    margin-top: 0.5rem;
+    overflow: hidden;
+    color: var(--theme-text-contrast);
+    font-weight: 600;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .discover_creator_entry,
+    .discover_creator_avatar,
+    .discover_creator_initials {
+        transition: none;
+    }
+}

--- a/resources/views/creator/card.blade.php
+++ b/resources/views/creator/card.blade.php
@@ -3,8 +3,9 @@
 use App\Models\User;
 
 /**
- * A single creator tile. Shared by the creator directory and the featured row on the discover
- * landing page, so it must not assume either page's surrounding layout.
+ * A single creator tile, as the creator directory renders it. The featured-creators strip on the
+ * per-dungeon route page deliberately uses its own flatter markup instead - see
+ * creator/featured.blade.php for why.
  *
  * @var User $creator
  */

--- a/resources/views/creator/card.blade.php
+++ b/resources/views/creator/card.blade.php
@@ -3,7 +3,7 @@
 use App\Models\User;
 
 /**
- * A single creator tile, as the creator directory renders it. The featured-creators strip on the
+ * A single creator tile, as the creator directory renders it. The featured-creators rail on the
  * per-dungeon route page deliberately uses its own flatter markup instead - see
  * creator/featured.blade.php for why.
  *

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -4,10 +4,18 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
- * The featured-creators row on the discover landing page.
+ * The featured-creators strip that closes the reworked per-dungeon route page.
+ *
+ * It sits below the leaderboard rather than above the routes on purpose: the person finding a route
+ * outranks the person who built one, so creators are the hand-off once the routes have been
+ * scanned, not the thing standing between the visitor and them.
+ *
+ * The entries are deliberately not creator.card - that tile is the directory's skin, and stacking a
+ * grid of cards under the leaderboard would reintroduce the visual weight the page has just spent
+ * two sections shedding. See creator-featured.css.
  *
  * featuredCreators is supplied by FeaturedCreatorsComposer rather than by the controller, because
- * three different controller methods render the discover landing.
+ * several controller methods render the pages this partial is included from.
  *
  * @var Collection<int, User> $featuredCreators
  */
@@ -15,24 +23,45 @@ use Illuminate\Database\Eloquent\Collection;
 $featuredCreators ??= collect();
 ?>
 @if($featuredCreators->isNotEmpty())
-    <div class="discover_panel px-xl-2">
-        <div class="row mt-4 align-items-center">
-            <div class="col">
-                <h2 class="h4 mb-0">
+    <div class="row mt-5 align-items-center discover_section_header">
+        <div class="col">
+            <h5 class="mb-0 text-center">
+                {{-- The directory link lives in the heading itself, matching the "Weekly routes" section above --}}
+                <a href="{{ route('creators.index') }}" title="{{ __('view_creator.featured.see_all') }}">
                     {{ __('view_creator.featured.title') }}
-                </h2>
-            </div>
-            <div class="col-auto">
-                <a href="{{ route('creators.index') }}">
-                    {{ __('view_creator.featured.see_all') }} &raquo;
+                    <i class="fas fa-angle-right" aria-hidden="true"></i>
                 </a>
-            </div>
+            </h5>
         </div>
+    </div>
 
-        <div class="row g-3 mt-1 row-cols-2 row-cols-md-4 row-cols-xl-6">
+    <div class="discover_creator_strip mt-2">
+        <div class="row g-2 row-cols-2 row-cols-sm-3 row-cols-lg-6">
             @foreach($featuredCreators as $creator)
+                <?php
+                // Set by the withCount() in CreatorDirectoryService; fall back rather than lazy-count per entry
+                $publishedRouteCount = $creator->published_route_count ?? 0;
+                ?>
                 <div class="col">
-                    @include('creator.card', ['creator' => $creator])
+                    <a href="{{ route('profile.view', ['user' => $creator]) }}" class="discover_creator_entry">
+                        @if($creator->iconfile !== null)
+                            <img src="{{ $creator->iconfile->getURL() }}"
+                                 alt="{{ $creator->name }}"
+                                 class="discover_creator_avatar"/>
+                        @else
+                            <div class="discover_creator_initials" aria-hidden="true">
+                                {{ $creator->initials }}
+                            </div>
+                        @endif
+
+                        <div class="discover_creator_name" title="{{ $creator->name }}">
+                            {{ $creator->name }}
+                        </div>
+
+                        <div class="text-body-secondary small">
+                            {{ trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]) }}
+                        </div>
+                    </a>
                 </div>
             @endforeach
         </div>

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -15,12 +15,12 @@ use Illuminate\Database\Eloquent\Collection;
  * two sections shedding. See creator-featured.css.
  *
  * featuredCreators is supplied by FeaturedCreatorsComposer rather than by the controller, because
- * several controller methods render the pages this partial is included from.
+ * several controller methods render the pages this partial is included from. It is deliberately not
+ * defaulted here: the composer is bound to this exact view, so an undefined variable means the
+ * binding is gone - which should be a loud error, not a section that silently stops rendering.
  *
  * @var Collection<int, User> $featuredCreators
  */
-
-$featuredCreators ??= collect();
 ?>
 @if($featuredCreators->isNotEmpty())
     <div class="row mt-5 align-items-center discover_section_header">
@@ -45,8 +45,9 @@ $featuredCreators ??= collect();
                 <div class="col">
                     <a href="{{ route('profile.view', ['user' => $creator]) }}" class="discover_creator_entry">
                         @if($creator->iconfile !== null)
+                            {{-- Decorative: the name is already the link's own text, right below it --}}
                             <img src="{{ $creator->iconfile->getURL() }}"
-                                 alt="{{ $creator->name }}"
+                                 alt=""
                                  class="discover_creator_avatar"/>
                         @else
                             <div class="discover_creator_initials" aria-hidden="true">

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+
+/**
+ * The featured-creators row on the discover landing page.
+ *
+ * featuredCreators is supplied by FeaturedCreatorsComposer rather than by the controller, because
+ * three different controller methods render the discover landing.
+ *
+ * @var Collection<int, User> $featuredCreators
+ */
+
+$featuredCreators ??= collect();
+?>
+@if($featuredCreators->isNotEmpty())
+    <div class="discover_panel px-xl-2">
+        <div class="row mt-4 align-items-center">
+            <div class="col">
+                <h2 class="h4 mb-0">
+                    {{ __('view_creator.featured.title') }}
+                </h2>
+            </div>
+            <div class="col-auto">
+                <a href="{{ route('creators.index') }}">
+                    {{ __('view_creator.featured.see_all') }} &raquo;
+                </a>
+            </div>
+        </div>
+
+        <div class="row g-3 mt-1 row-cols-2 row-cols-md-4 row-cols-xl-8">
+            @foreach($featuredCreators as $creator)
+                <div class="col">
+                    @include('creator.card', ['creator' => $creator])
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endif

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -29,7 +29,9 @@ use Illuminate\Database\Eloquent\Collection;
  */
 ?>
 @if($featuredCreators->isNotEmpty())
-    <div class="discover_creator_rail mt-4">
+    {{-- A named landmark rather than a heading: dropping the heading row left seven sibling links
+         with nothing to announce or navigate to them by. What this is, is navigation. --}}
+    <nav class="discover_creator_rail mt-4" aria-label="{{ __('view_creator.featured.title') }}">
         {{-- The directory link is the rail's own label, so the rail needs no separate heading row --}}
         <a href="{{ route('creators.index') }}"
            class="discover_creator_rail_label"
@@ -45,7 +47,12 @@ use Illuminate\Database\Eloquent\Collection;
             ?>
             <a href="{{ route('profile.view', ['user' => $creator]) }}"
                class="discover_creator_entry"
-               title="{{ trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]) }}">
+               {{-- Carries the name too, not just the count: the name clips to an ellipsis at rail
+                    width (always, under the phone cap) and the tooltip is its only reveal path --}}
+               title="{{ __('view_creator.featured.entry_title', [
+                   'name'   => $creator->name,
+                   'routes' => trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]),
+               ]) }}">
                 @if($creator->iconfile !== null)
                     {{-- Decorative: the name is already the link's own text, right beside it --}}
                     <img src="{{ $creator->iconfile->getURL() }}"
@@ -62,5 +69,5 @@ use Illuminate\Database\Eloquent\Collection;
                 </span>
             </a>
         @endforeach
-    </div>
+    </nav>
 @endif

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -13,9 +13,13 @@ use Illuminate\Database\Eloquent\Collection;
  *
  * Opening the page is what makes it a rail rather than a section. A six-across grid of tiles here
  * would cold-open the page on creators and push the routes the visitor came for below the fold; one
- * line of avatar-plus-name costs about 80px and reads as a caption above the hero, not as a section
- * competing with it. The published route count moves into the link's tooltip - at rail scale it is
- * noise, and the directory one click away is where counts belong.
+ * row of horizontal entries costs about 100px and reads as a caption above the hero, not as a
+ * section competing with it.
+ *
+ * Two earlier passes read as a list of tags rather than as people, and neither cause was size: the
+ * label sat inline ahead of the entries ("label: item item item" is tag-list grammar), and each
+ * entry carried one short string. Hence the heading on its own line, and the published route count
+ * under each name - which is also the evidence that makes a featured creator worth clicking.
  *
  * The entries are deliberately not creator.card: that tile is the directory's skin, and its fixed
  * vertical composition cannot compress to a rail. See creator-featured.css.
@@ -32,42 +36,54 @@ use Illuminate\Database\Eloquent\Collection;
     {{-- A named landmark rather than a heading: dropping the heading row left seven sibling links
          with nothing to announce or navigate to them by. What this is, is navigation. --}}
     <nav class="discover_creator_rail mt-4" aria-label="{{ __('view_creator.featured.title') }}">
-        {{-- The directory link is the rail's own label, so the rail needs no separate heading row --}}
-        <a href="{{ route('creators.index') }}"
-           class="discover_creator_rail_label"
-           title="{{ __('view_creator.featured.see_all') }}">
-            {{ __('view_creator.featured.title') }}
-            <i class="fas fa-angle-right" aria-hidden="true"></i>
-        </a>
-
-        @foreach($featuredCreators as $creator)
-            <?php
-            // Set by the withCount() in CreatorDirectoryService; fall back rather than lazy-count per entry
-            $publishedRouteCount = $creator->published_route_count ?? 0;
-            ?>
-            <a href="{{ route('profile.view', ['user' => $creator]) }}"
-               class="discover_creator_entry"
-               {{-- Carries the name too, not just the count: the name clips to an ellipsis at rail
-                    width (always, under the phone cap) and the tooltip is its only reveal path --}}
-               title="{{ __('view_creator.featured.entry_title', [
-                   'name'   => $creator->name,
-                   'routes' => trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]),
-               ]) }}">
-                @if($creator->iconfile !== null)
-                    {{-- Decorative: the name is already the link's own text, right beside it --}}
-                    <img src="{{ $creator->iconfile->getURL() }}"
-                         alt=""
-                         class="discover_creator_avatar"/>
-                @else
-                    <span class="discover_creator_initials" aria-hidden="true">
-                        {{ $creator->initials }}
-                    </span>
-                @endif
-
-                <span class="discover_creator_name">
-                    {{ $creator->name }}
-                </span>
+        {{-- On its own line, not inline ahead of the entries: "label: item item item" on one line is
+             the grammar of a tag list, and the rail read as one. The link doubles as the label. --}}
+        <div class="discover_creator_rail_heading">
+            <a href="{{ route('creators.index') }}"
+               class="discover_creator_rail_label"
+               title="{{ __('view_creator.featured.see_all') }}">
+                {{ __('view_creator.featured.title') }}
+                <i class="fas fa-angle-right" aria-hidden="true"></i>
             </a>
-        @endforeach
+        </div>
+
+        <div class="discover_creator_rail_entries">
+            @foreach($featuredCreators as $creator)
+                <?php
+                // Set by the withCount() in CreatorDirectoryService; fall back rather than lazy-count per entry
+                $publishedRouteCount = $creator->published_route_count ?? 0;
+                ?>
+                <a href="{{ route('profile.view', ['user' => $creator]) }}"
+                   class="discover_creator_entry"
+                   {{-- Carries the name too, not just the count: the name clips to an ellipsis at
+                        rail width (always, under the phone cap) and the tooltip is its reveal path --}}
+                   title="{{ __('view_creator.featured.entry_title', [
+                       'name'   => $creator->name,
+                       'routes' => trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]),
+                   ]) }}">
+                    @if($creator->iconfile !== null)
+                        {{-- Decorative: the name is already the link's own text, right beside it --}}
+                        <img src="{{ $creator->iconfile->getURL() }}"
+                             alt=""
+                             class="discover_creator_avatar"/>
+                    @else
+                        <span class="discover_creator_initials" aria-hidden="true">
+                            {{ $creator->initials }}
+                        </span>
+                    @endif
+
+                    <span class="discover_creator_text">
+                        <span class="discover_creator_name">
+                            {{ $creator->name }}
+                        </span>
+                        {{-- The count is the evidence that makes a featured creator worth a click;
+                             hiding it in the tooltip is what made an entry read as a bare tag --}}
+                        <span class="discover_creator_count text-body-secondary">
+                            {{ trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]) }}
+                        </span>
+                    </span>
+                </a>
+            @endforeach
+        </div>
     </nav>
 @endif

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -4,15 +4,21 @@ use App\Models\User;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
- * The featured-creators strip that closes the reworked per-dungeon route page.
+ * The featured-creators rail that opens the reworked per-dungeon route page.
  *
- * It sits below the leaderboard rather than above the routes on purpose: the person finding a route
- * outranks the person who built one, so creators are the hand-off once the routes have been
- * scanned, not the thing standing between the visitor and them.
+ * It sits above the hero band, and it cannot sit between the hero band and the leaderboard even
+ * though that looks like the natural middle ground: with no Raider.IO weekly routes the hero band is
+ * the top three of the same popular query and the leaderboard's startRank continues from it, so a
+ * section wedged in there splits ranks 1-3 from 4-onwards.
  *
- * The entries are deliberately not creator.card - that tile is the directory's skin, and stacking a
- * grid of cards under the leaderboard would reintroduce the visual weight the page has just spent
- * two sections shedding. See creator-featured.css.
+ * Opening the page is what makes it a rail rather than a section. A six-across grid of tiles here
+ * would cold-open the page on creators and push the routes the visitor came for below the fold; one
+ * line of avatar-plus-name costs about 80px and reads as a caption above the hero, not as a section
+ * competing with it. The published route count moves into the link's tooltip - at rail scale it is
+ * noise, and the directory one click away is where counts belong.
+ *
+ * The entries are deliberately not creator.card: that tile is the directory's skin, and its fixed
+ * vertical composition cannot compress to a rail. See creator-featured.css.
  *
  * featuredCreators is supplied by FeaturedCreatorsComposer rather than by the controller, because
  * several controller methods render the pages this partial is included from. It is deliberately not
@@ -23,48 +29,38 @@ use Illuminate\Database\Eloquent\Collection;
  */
 ?>
 @if($featuredCreators->isNotEmpty())
-    <div class="row mt-5 align-items-center discover_section_header">
-        <div class="col">
-            <h5 class="mb-0 text-center">
-                {{-- The directory link lives in the heading itself, matching the "Weekly routes" section above --}}
-                <a href="{{ route('creators.index') }}" title="{{ __('view_creator.featured.see_all') }}">
-                    {{ __('view_creator.featured.title') }}
-                    <i class="fas fa-angle-right" aria-hidden="true"></i>
-                </a>
-            </h5>
-        </div>
-    </div>
+    <div class="discover_creator_rail mt-4">
+        {{-- The directory link is the rail's own label, so the rail needs no separate heading row --}}
+        <a href="{{ route('creators.index') }}"
+           class="discover_creator_rail_label"
+           title="{{ __('view_creator.featured.see_all') }}">
+            {{ __('view_creator.featured.title') }}
+            <i class="fas fa-angle-right" aria-hidden="true"></i>
+        </a>
 
-    <div class="discover_creator_strip mt-2">
-        <div class="row g-2 row-cols-2 row-cols-sm-3 row-cols-lg-6">
-            @foreach($featuredCreators as $creator)
-                <?php
-                // Set by the withCount() in CreatorDirectoryService; fall back rather than lazy-count per entry
-                $publishedRouteCount = $creator->published_route_count ?? 0;
-                ?>
-                <div class="col">
-                    <a href="{{ route('profile.view', ['user' => $creator]) }}" class="discover_creator_entry">
-                        @if($creator->iconfile !== null)
-                            {{-- Decorative: the name is already the link's own text, right below it --}}
-                            <img src="{{ $creator->iconfile->getURL() }}"
-                                 alt=""
-                                 class="discover_creator_avatar"/>
-                        @else
-                            <div class="discover_creator_initials" aria-hidden="true">
-                                {{ $creator->initials }}
-                            </div>
-                        @endif
+        @foreach($featuredCreators as $creator)
+            <?php
+            // Set by the withCount() in CreatorDirectoryService; fall back rather than lazy-count per entry
+            $publishedRouteCount = $creator->published_route_count ?? 0;
+            ?>
+            <a href="{{ route('profile.view', ['user' => $creator]) }}"
+               class="discover_creator_entry"
+               title="{{ trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]) }}">
+                @if($creator->iconfile !== null)
+                    {{-- Decorative: the name is already the link's own text, right beside it --}}
+                    <img src="{{ $creator->iconfile->getURL() }}"
+                         alt=""
+                         class="discover_creator_avatar"/>
+                @else
+                    <span class="discover_creator_initials" aria-hidden="true">
+                        {{ $creator->initials }}
+                    </span>
+                @endif
 
-                        <div class="discover_creator_name" title="{{ $creator->name }}">
-                            {{ $creator->name }}
-                        </div>
-
-                        <div class="text-body-secondary small">
-                            {{ trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]) }}
-                        </div>
-                    </a>
-                </div>
-            @endforeach
-        </div>
+                <span class="discover_creator_name">
+                    {{ $creator->name }}
+                </span>
+            </a>
+        @endforeach
     </div>
 @endif

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -29,7 +29,7 @@ $featuredCreators ??= collect();
             </div>
         </div>
 
-        <div class="row g-3 mt-1 row-cols-2 row-cols-md-4 row-cols-xl-8">
+        <div class="row g-3 mt-1 row-cols-2 row-cols-md-4 row-cols-xl-6">
             @foreach($featuredCreators as $creator)
                 <div class="col">
                     @include('creator.card', ['creator' => $creator])

--- a/resources/views/creator/featured.blade.php
+++ b/resources/views/creator/featured.blade.php
@@ -13,8 +13,8 @@ use Illuminate\Database\Eloquent\Collection;
  *
  * Opening the page is what makes it a rail rather than a section. A six-across grid of tiles here
  * would cold-open the page on creators and push the routes the visitor came for below the fold; one
- * row of horizontal entries costs about 100px and reads as a caption above the hero, not as a
- * section competing with it.
+ * row of horizontal entries costs 94px and reads as a caption above the hero, not as a section
+ * competing with it.
  *
  * Two earlier passes read as a list of tags rather than as people, and neither cause was size: the
  * label sat inline ahead of the entries ("label: item item item" is tag-list grammar), and each
@@ -33,8 +33,9 @@ use Illuminate\Database\Eloquent\Collection;
  */
 ?>
 @if($featuredCreators->isNotEmpty())
-    {{-- A named landmark rather than a heading: dropping the heading row left seven sibling links
-         with nothing to announce or navigate to them by. What this is, is navigation. --}}
+    {{-- A named landmark rather than a heading: the label is a link, not a heading element, so
+         without this the rail is a run of sibling links at the top of the page with nothing to
+         announce it or navigate to it by. What this is, is navigation. --}}
     <nav class="discover_creator_rail mt-4" aria-label="{{ __('view_creator.featured.title') }}">
         {{-- On its own line, not inline ahead of the entries: "label: item item item" on one line is
              the grammar of a tag list, and the rail read as one. The link doubles as the label. --}}
@@ -55,8 +56,8 @@ use Illuminate\Database\Eloquent\Collection;
                 ?>
                 <a href="{{ route('profile.view', ['user' => $creator]) }}"
                    class="discover_creator_entry"
-                   {{-- Carries the name too, not just the count: the name clips to an ellipsis at
-                        rail width (always, under the phone cap) and the tooltip is its reveal path --}}
+                   {{-- Carries the name too, not just the count: a long name clips to an ellipsis at
+                        the entry's fixed width, and the tooltip is its only reveal path --}}
                    title="{{ __('view_creator.featured.entry_title', [
                        'name'   => $creator->name,
                        'routes' => trans_choice('view_creator.card.route_count', $publishedRouteCount, ['count' => $publishedRouteCount]),

--- a/resources/views/dungeonroute/discover/discover.blade.php
+++ b/resources/views/dungeonroute/discover/discover.blade.php
@@ -50,10 +50,6 @@ $expansion ??= null;
         ])
     </div>
 
-    @feature(\App\Features\CreatorProfiles::class)
-        @include('creator.featured')
-    @endfeature
-
     @include('dungeonroute.discover.panel', [
         'gameVersion' => $gameVersion,
         'title' => __('view_dungeonroute.discover.discover.popular'),

--- a/resources/views/dungeonroute/discover/discover.blade.php
+++ b/resources/views/dungeonroute/discover/discover.blade.php
@@ -50,6 +50,10 @@ $expansion ??= null;
         ])
     </div>
 
+    @feature(\App\Features\CreatorProfiles::class)
+        @include('creator.featured')
+    @endfeature
+
     @include('dungeonroute.discover.panel', [
         'gameVersion' => $gameVersion,
         'title' => __('view_dungeonroute.discover.discover.popular'),

--- a/resources/views/dungeonroute/discover/dungeon/overview.blade.php
+++ b/resources/views/dungeonroute/discover/dungeon/overview.blade.php
@@ -68,6 +68,11 @@ use Laravel\Pennant\Feature;
             ($page === 1 ? $weeklyRoutes->pluck('dungeonRoute') : collect())->merge($popularItems)->unique('id')->values(),
         );
         ?>
+        <?php // Above the hero band, not between it and the leaderboard: startRank continues from the band into the list ?>
+        @feature(\App\Features\CreatorProfiles::class)
+            @include('creator.featured')
+        @endfeature
+
         @if($page === 1)
             @if($weeklyRoutes->isNotEmpty())
                 <div class="row mt-4 align-items-center discover_section_header">
@@ -151,11 +156,6 @@ use Laravel\Pennant\Feature;
                 </div>
             </div>
         @endif
-
-        <?php // Creators close the page rather than open it: the visitor came for a route, not for whoever wrote it ?>
-        @feature(\App\Features\CreatorProfiles::class)
-            @include('creator.featured')
-        @endfeature
 
         @if( !$adFree && !$isMobile)
             <div align="center" class="mt-4">

--- a/resources/views/dungeonroute/discover/dungeon/overview.blade.php
+++ b/resources/views/dungeonroute/discover/dungeon/overview.blade.php
@@ -152,6 +152,11 @@ use Laravel\Pennant\Feature;
             </div>
         @endif
 
+        <?php // Creators close the page rather than open it: the visitor came for a route, not for whoever wrote it ?>
+        @feature(\App\Features\CreatorProfiles::class)
+            @include('creator.featured')
+        @endfeature
+
         @if( !$adFree && !$isMobile)
             <div align="center" class="mt-4">
                 @include('common.thirdparty.adunit', ['id' => 'site_middle_discover', 'type' => 'header', 'reportAdPosition' => 'top-right'])

--- a/tests/Feature/Controller/FeaturedCreatorsTest.php
+++ b/tests/Feature/Controller/FeaturedCreatorsTest.php
@@ -28,7 +28,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
         $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
 
         try {
-            // Act - a generous limit, because the featured strip is ranked by published route count
+            // Act - a generous limit, because the featured rail is ranked by published route count
             // and a brand new creator at the threshold sits below the established ones
             $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(PHP_INT_MAX);
 
@@ -44,7 +44,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
     }
 
     /**
-     * The featured strip and the directory must agree on who counts as a creator - they share
+     * The featured rail and the directory must agree on who counts as a creator - they share
      * buildListedCreatorsQuery() precisely so the opt-out cannot be honoured on one and ignored on
      * the other.
      */
@@ -101,9 +101,9 @@ final class FeaturedCreatorsTest extends PublicTestCase
     }
 
     #[Test]
-    public function discoverDungeon_givenBothFlagsActive_rendersTheFeaturedStrip(): void
+    public function discoverDungeon_givenBothFlagsActive_rendersTheFeaturedRail(): void
     {
-        // Arrange - a creator at the threshold guarantees the strip has at least one entry to render
+        // Arrange - a creator at the threshold guarantees the rail has at least one entry to render
         Feature::define(CreatorProfiles::class, true);
         Feature::define(DungeonRouteListRework::class, true);
 
@@ -111,7 +111,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
         $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
 
         try {
-            // The strip is truncated to featured_count and ranked by published route count, so the
+            // The rail is truncated to featured_count and ranked by published route count, so the
             // creator arranged above isn't guaranteed a spot on a seeded database. Assert against
             // whoever the service actually features instead of assuming it is them.
             $featuredCreator = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators()->first();
@@ -120,9 +120,9 @@ final class FeaturedCreatorsTest extends PublicTestCase
             // Act
             $response = $this->get($this->dungeonRouteListUrl());
 
-            // Assert - the section, its heading link into the directory, and the featured creator
+            // Assert - the rail, its label linking into the directory, and the featured creator
             $response->assertOk();
-            $response->assertSee('discover_creator_strip', false);
+            $response->assertSee('discover_creator_rail', false);
             $response->assertSee(__('view_creator.featured.title'));
             $response->assertSee(route('creators.index'), false);
             $response->assertSee($featuredCreator->name);
@@ -133,7 +133,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
     }
 
     #[Test]
-    public function discoverDungeon_givenCreatorProfilesInactive_doesNotRenderTheFeaturedStrip(): void
+    public function discoverDungeon_givenCreatorProfilesInactive_doesNotRenderTheFeaturedRail(): void
     {
         // Arrange
         Feature::define(CreatorProfiles::class, false);
@@ -144,16 +144,16 @@ final class FeaturedCreatorsTest extends PublicTestCase
 
         // Assert
         $response->assertOk();
-        $response->assertDontSee('discover_creator_strip', false);
+        $response->assertDontSee('discover_creator_rail', false);
         $response->assertDontSee(__('view_creator.featured.title'));
     }
 
     /**
-     * The strip is written for the reworked hero-band/leaderboard layout and is included from that
+     * The rail is written for the reworked hero-band/leaderboard layout and is included from that
      * branch only - it must not leak into the legacy multi-panel overview it was never styled for.
      */
     #[Test]
-    public function discoverDungeon_givenListReworkInactive_doesNotRenderTheFeaturedStrip(): void
+    public function discoverDungeon_givenListReworkInactive_doesNotRenderTheFeaturedRail(): void
     {
         // Arrange
         Feature::define(CreatorProfiles::class, true);
@@ -164,13 +164,13 @@ final class FeaturedCreatorsTest extends PublicTestCase
 
         // Assert
         $response->assertOk();
-        $response->assertDontSee('discover_creator_strip', false);
+        $response->assertDontSee('discover_creator_rail', false);
         $response->assertDontSee(__('view_creator.featured.title'));
     }
 
     /**
      * The per-dungeon route page - the page "Browse routes" actually lands on, and the one the
-     * featured strip closes.
+     * featured rail opens.
      */
     private function dungeonRouteListUrl(): string
     {

--- a/tests/Feature/Controller/FeaturedCreatorsTest.php
+++ b/tests/Feature/Controller/FeaturedCreatorsTest.php
@@ -3,11 +3,13 @@
 namespace Tests\Feature\Controller;
 
 use App\Features\CreatorProfiles;
+use App\Features\DungeonRouteListRework;
+use App\Models\Dungeon;
 use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\GameVersion\GameVersion;
 use App\Models\PublishedState;
 use App\Models\User;
 use App\Service\Creator\CreatorDirectoryServiceInterface;
-use App\Service\Season\SeasonServiceInterface;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Laravel\Pennant\Feature;
 use PHPUnit\Framework\Attributes\Group;
@@ -15,6 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('Controller')]
+#[Group('Discover')]
 final class FeaturedCreatorsTest extends PublicTestCase
 {
     #[Test]
@@ -25,7 +28,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
         $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
 
         try {
-            // Act - a generous limit, because the featured row is ranked by published route count
+            // Act - a generous limit, because the featured strip is ranked by published route count
             // and a brand new creator at the threshold sits below the established ones
             $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(PHP_INT_MAX);
 
@@ -41,7 +44,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
     }
 
     /**
-     * The featured row and the directory must agree on who counts as a creator - they share
+     * The featured strip and the directory must agree on who counts as a creator - they share
      * buildListedCreatorsQuery() precisely so the opt-out cannot be honoured on one and ignored on
      * the other.
      */
@@ -59,7 +62,7 @@ final class FeaturedCreatorsTest extends PublicTestCase
             // Assert
             $this->assertFalse(
                 $featured->pluck('id')->contains($creator->id),
-                'A creator who opted out must not be featured on the discover landing either',
+                'A creator who opted out must not be featured on the route page either',
             );
         } finally {
             $this->deleteAll($routes);
@@ -78,75 +81,92 @@ final class FeaturedCreatorsTest extends PublicTestCase
     }
 
     #[Test]
-    public function discover_givenFeatureInactive_doesNotRenderTheFeaturedRow(): void
+    public function discoverDungeon_givenBothFlagsActive_rendersTheFeaturedStrip(): void
     {
-        // Arrange
-        $viewer = User::factory()->create();
-        Feature::for($viewer)->deactivate(CreatorProfiles::class);
+        // Arrange - a creator at the threshold guarantees the strip has at least one entry to render
+        Feature::define(CreatorProfiles::class, true);
+        Feature::define(DungeonRouteListRework::class, true);
+
+        $creator = User::factory()->create();
+        $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
 
         try {
-            // Act
-            $response = $this->actingAs($viewer)->followingRedirects()->get($this->discoverUrl());
+            // The strip is truncated to featured_count and ranked by published route count, so the
+            // creator arranged above isn't guaranteed a spot on a seeded database. Assert against
+            // whoever the service actually features instead of assuming it is them.
+            $featuredCreator = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators()->first();
+            $this->assertNotNull($featuredCreator, 'Expected at least one listed creator to feature');
 
-            // Assert
+            // Act
+            $response = $this->get($this->dungeonRouteListUrl());
+
+            // Assert - the section, its heading link into the directory, and the featured creator
             $response->assertOk();
-            $response->assertDontSee(__('view_creator.featured.title'));
+            $response->assertSee('discover_creator_strip', false);
+            $response->assertSee(__('view_creator.featured.title'));
+            $response->assertSee(route('creators.index'), false);
+            $response->assertSee($featuredCreator->name);
         } finally {
-            Feature::for($viewer)->forget(CreatorProfiles::class);
-            $viewer->delete();
+            $this->deleteAll($routes);
+            $creator->delete();
         }
     }
 
     #[Test]
-    public function discover_givenFeatureActiveAndAListedCreator_rendersTheFeaturedRow(): void
+    public function discoverDungeon_givenCreatorProfilesInactive_doesNotRenderTheFeaturedStrip(): void
     {
         // Arrange
-        $viewer  = User::factory()->create();
-        $creator = User::factory()->create();
-        $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
+        Feature::define(CreatorProfiles::class, false);
+        Feature::define(DungeonRouteListRework::class, true);
 
-        Feature::for($viewer)->activate(CreatorProfiles::class);
+        // Act
+        $response = $this->get($this->dungeonRouteListUrl());
 
-        try {
-            // Act
-            $response = $this->actingAs($viewer)->followingRedirects()->get($this->discoverUrl());
-
-            // Assert
-            $response->assertOk();
-            $response->assertSee(__('view_creator.featured.title'));
-            $response->assertSee(__('view_creator.featured.see_all'));
-
-            // The row is truncated to featured_count and ranked by published route count, so a
-            // creator at the threshold isn't guaranteed a spot on the seeded test DB's rendered
-            // page - assert eligibility against the unlimited query instead, matching
-            // getFeaturedCreators_givenACreatorAboveTheThreshold_includesThem.
-            $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(PHP_INT_MAX);
-            $this->assertTrue(
-                $featured->pluck('id')->contains($creator->id),
-                'The arranged creator must be eligible to be featured',
-            );
-        } finally {
-            Feature::for($viewer)->forget(CreatorProfiles::class);
-            $this->deleteAll($routes);
-            $creator->delete();
-            $viewer->delete();
-        }
+        // Assert
+        $response->assertOk();
+        $response->assertDontSee('discover_creator_strip', false);
+        $response->assertDontSee(__('view_creator.featured.title'));
     }
 
     /**
-     * A URL that actually renders dungeonroute.discover.discover.
-     *
-     * Deliberately not route('dungeonroutes'): that redirects by game version and then by the
-     * viewer's dungeon context, which in a seeded environment lands on a per-dungeon page that
-     * renders a different view entirely.
+     * The strip is written for the reworked hero-band/leaderboard layout and is included from that
+     * branch only - it must not leak into the legacy multi-panel overview it was never styled for.
      */
-    private function discoverUrl(): string
+    #[Test]
+    public function discoverDungeon_givenListReworkInactive_doesNotRenderTheFeaturedStrip(): void
     {
-        $season = app(SeasonServiceInterface::class)->getCurrentSeason();
+        // Arrange
+        Feature::define(CreatorProfiles::class, true);
+        Feature::define(DungeonRouteListRework::class, false);
 
-        return route('dungeonroutes.expansion.season', [
-            'expansion' => $season->expansion,
-            'season'    => $season->index,
+        // Act
+        $response = $this->get($this->dungeonRouteListUrl());
+
+        // Assert
+        $response->assertOk();
+        $response->assertDontSee('discover_creator_strip', false);
+        $response->assertDontSee(__('view_creator.featured.title'));
+    }
+
+    /**
+     * The per-dungeon route page - the page "Browse routes" actually lands on, and the one the
+     * featured strip closes.
+     */
+    private function dungeonRouteListUrl(): string
+    {
+        /** @var Dungeon|null $dungeon */
+        $dungeon = Dungeon::query()
+            ->where('active', true)
+            ->whereNotNull('challenge_mode_id')
+            ->with('floors')
+            ->get()
+            ->first(fn(Dungeon $dungeon) => $dungeon->getCurrentMappingVersion() !== null && $dungeon->floors->isNotEmpty());
+
+        $this->assertNotNull($dungeon, 'Expected an active dungeon with a mapping version in the seeded database');
+
+        return route('dungeonroutes.discoverdungeon', [
+            'gameVersion' => GameVersion::findOrFail($dungeon->getCurrentMappingVersion()->game_version_id),
+            'dungeon'     => $dungeon,
         ]);
     }
 

--- a/tests/Feature/Controller/FeaturedCreatorsTest.php
+++ b/tests/Feature/Controller/FeaturedCreatorsTest.php
@@ -70,14 +70,34 @@ final class FeaturedCreatorsTest extends PublicTestCase
         }
     }
 
+    /**
+     * Arranging three eligible creators is what gives this test teeth: asserting "at most 2" against
+     * whatever the database happens to hold passes on an empty result, and keeps passing with the
+     * limit() removed entirely.
+     */
     #[Test]
-    public function getFeaturedCreators_givenALimit_returnsAtMostThatMany(): void
+    public function getFeaturedCreators_givenALimit_returnsExactlyThatMany(): void
     {
-        // Act
-        $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(2);
+        // Arrange
+        $creators = new EloquentCollection();
+        $routes   = new EloquentCollection();
 
-        // Assert
-        $this->assertLessThanOrEqual(2, $featured->count(), 'The limit must be respected');
+        for ($i = 0; $i < 3; $i++) {
+            $creator = User::factory()->create();
+            $creators->push($creator);
+            $routes->push(...$this->createPublishedRoutesFor($creator, $this->minPublishedRoutes()));
+        }
+
+        try {
+            // Act
+            $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(2);
+
+            // Assert
+            $this->assertCount(2, $featured, 'The limit must be respected');
+        } finally {
+            $this->deleteAll($routes);
+            $creators->each(fn(User $creator) => $creator->delete());
+        }
     }
 
     #[Test]

--- a/tests/Feature/Controller/FeaturedCreatorsTest.php
+++ b/tests/Feature/Controller/FeaturedCreatorsTest.php
@@ -115,6 +115,16 @@ final class FeaturedCreatorsTest extends PublicTestCase
             $response->assertOk();
             $response->assertSee(__('view_creator.featured.title'));
             $response->assertSee(__('view_creator.featured.see_all'));
+
+            // The row is truncated to featured_count and ranked by published route count, so a
+            // creator at the threshold isn't guaranteed a spot on the seeded test DB's rendered
+            // page - assert eligibility against the unlimited query instead, matching
+            // getFeaturedCreators_givenACreatorAboveTheThreshold_includesThem.
+            $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(PHP_INT_MAX);
+            $this->assertTrue(
+                $featured->pluck('id')->contains($creator->id),
+                'The arranged creator must be eligible to be featured',
+            );
         } finally {
             Feature::for($viewer)->forget(CreatorProfiles::class);
             $this->deleteAll($routes);

--- a/tests/Feature/Controller/FeaturedCreatorsTest.php
+++ b/tests/Feature/Controller/FeaturedCreatorsTest.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Tests\Feature\Controller;
+
+use App\Features\CreatorProfiles;
+use App\Models\DungeonRoute\DungeonRoute;
+use App\Models\PublishedState;
+use App\Models\User;
+use App\Service\Creator\CreatorDirectoryServiceInterface;
+use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Laravel\Pennant\Feature;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('Controller')]
+final class FeaturedCreatorsTest extends PublicTestCase
+{
+    #[Test]
+    public function getFeaturedCreators_givenACreatorAboveTheThreshold_includesThem(): void
+    {
+        // Arrange
+        $creator = User::factory()->create();
+        $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
+
+        try {
+            // Act - a generous limit, because the featured row is ranked by published route count
+            // and a brand new creator at the threshold sits below the established ones
+            $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(PHP_INT_MAX);
+
+            // Assert
+            $this->assertTrue(
+                $featured->pluck('id')->contains($creator->id),
+                'A creator at the threshold must be eligible to be featured',
+            );
+        } finally {
+            $this->deleteAll($routes);
+            $creator->delete();
+        }
+    }
+
+    /**
+     * The featured row and the directory must agree on who counts as a creator - they share
+     * buildListedCreatorsQuery() precisely so the opt-out cannot be honoured on one and ignored on
+     * the other.
+     */
+    #[Test]
+    public function getFeaturedCreators_givenACreatorWhoOptedOut_excludesThem(): void
+    {
+        // Arrange
+        $creator = User::factory()->create(['hide_from_creator_directory' => true]);
+        $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
+
+        try {
+            // Act
+            $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(PHP_INT_MAX);
+
+            // Assert
+            $this->assertFalse(
+                $featured->pluck('id')->contains($creator->id),
+                'A creator who opted out must not be featured on the discover landing either',
+            );
+        } finally {
+            $this->deleteAll($routes);
+            $creator->delete();
+        }
+    }
+
+    #[Test]
+    public function getFeaturedCreators_givenALimit_returnsAtMostThatMany(): void
+    {
+        // Act
+        $featured = app(CreatorDirectoryServiceInterface::class)->getFeaturedCreators(2);
+
+        // Assert
+        $this->assertLessThanOrEqual(2, $featured->count(), 'The limit must be respected');
+    }
+
+    #[Test]
+    public function discover_givenFeatureInactive_doesNotRenderTheFeaturedRow(): void
+    {
+        // Arrange
+        $viewer = User::factory()->create();
+        Feature::for($viewer)->deactivate(CreatorProfiles::class);
+
+        try {
+            // Act
+            $response = $this->actingAs($viewer)->followingRedirects()->get($this->discoverUrl());
+
+            // Assert
+            $response->assertOk();
+            $response->assertDontSee(__('view_creator.featured.title'));
+        } finally {
+            Feature::for($viewer)->forget(CreatorProfiles::class);
+            $viewer->delete();
+        }
+    }
+
+    #[Test]
+    public function discover_givenFeatureActiveAndAListedCreator_rendersTheFeaturedRow(): void
+    {
+        // Arrange
+        $viewer  = User::factory()->create();
+        $creator = User::factory()->create();
+        $routes  = $this->createPublishedRoutesFor($creator, $this->minPublishedRoutes());
+
+        Feature::for($viewer)->activate(CreatorProfiles::class);
+
+        try {
+            // Act
+            $response = $this->actingAs($viewer)->followingRedirects()->get($this->discoverUrl());
+
+            // Assert
+            $response->assertOk();
+            $response->assertSee(__('view_creator.featured.title'));
+            $response->assertSee(__('view_creator.featured.see_all'));
+        } finally {
+            Feature::for($viewer)->forget(CreatorProfiles::class);
+            $this->deleteAll($routes);
+            $creator->delete();
+            $viewer->delete();
+        }
+    }
+
+    /**
+     * A URL that actually renders dungeonroute.discover.discover.
+     *
+     * Deliberately not route('dungeonroutes'): that redirects by game version and then by the
+     * viewer's dungeon context, which in a seeded environment lands on a per-dungeon page that
+     * renders a different view entirely.
+     */
+    private function discoverUrl(): string
+    {
+        $season = app(SeasonServiceInterface::class)->getCurrentSeason();
+
+        return route('dungeonroutes.expansion.season', [
+            'expansion' => $season->expansion,
+            'season'    => $season->index,
+        ]);
+    }
+
+    private function minPublishedRoutes(): int
+    {
+        return (int)config('keystoneguru.creators.min_published_routes');
+    }
+
+    /** @return EloquentCollection<int, DungeonRoute> */
+    private function createPublishedRoutesFor(User $creator, int $count): EloquentCollection
+    {
+        $routes = new EloquentCollection();
+
+        for ($i = 0; $i < $count; $i++) {
+            $routes->push(DungeonRoute::factory()->create([
+                'author_id'          => $creator->id,
+                'expires_at'         => null,
+                'published_state_id' => PublishedState::ALL[PublishedState::WORLD],
+            ]));
+        }
+
+        return $routes;
+    }
+
+    /** @param EloquentCollection<int, DungeonRoute> $routes */
+    private function deleteAll(EloquentCollection $routes): void
+    {
+        foreach ($routes as $route) {
+            $route->delete();
+        }
+    }
+}


### PR DESCRIPTION
:robot: Part of #1769.

**Rewritten on 2026-08-16.** The original version of this MR put a featured-creators row on the discover *landing* (`dungeonroute.discover.discover`), built against that page's legacy `discover.panel` layout. It has been rewritten for the page people actually reach. #3675 and #3676 have since merged, so this no longer carries their commits.

## Why it moved

"Browse routes" does not land on the discover landing. It redirects by game version and then by the viewer's dungeon context onto the **per-dungeon overview** (`/routes/retail/<dungeon>`), and that page has since been rebuilt behind `DungeonRouteListRework` — a cinematic hero band, a ranked leaderboard, compact pagination (#3447, #3650, #3978). A grid of bordered creator cards on the old landing no longer describes where creators should appear, or what they should look like when they get there.

| | Before | After |
|---|---|---|
| Page | discover landing (`/routes/retail/season/N`) | per-dungeon overview (`/routes/retail/<dungeon>`) |
| Position | above the route lists | a one-line 94px rail above the hero band |
| Markup | `@include('creator.card')` in a `row-cols` grid | its own horizontal entries in a scrolling shelf |
| Heading | `h2.h4` + right-aligned "See all »" cell | a centred label line that is itself the directory link |
| Flags | `CreatorProfiles` | `CreatorProfiles` **and** `DungeonRouteListRework` |

![featured creators rail](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/1769-rail-darkly.png)

## The decisions worth reviewing

**It cannot sit between the hero band and the leaderboard**, which looks like the natural middle ground for a section that shouldn't outrank the routes. With no Raider.IO weekly routes the hero band is the top three of the same popular query, and the leaderboard's `startRank` continues from it — so a section wedged in there splits ranks 1‑2‑3 from 4‑onwards. It goes above the band instead.

**Opening the page is what makes it a rail rather than a section.** A six-across grid of tiles here would cold-open the page on creators and push the routes the visitor came for below the fold. One row of horizontal entries costs 94px and reads as a caption above the hero.

**It took two passes to stop reading as a list of tags**, and neither cause was size. The label sat inline ahead of the entries — `label: item item item` on one line is the grammar of a tag list. And each entry carried a single short string, because the first compaction pass moved the route count into a tooltip. So the label now has its own line, and the count is back under the name: it is the evidence that makes a featured creator worth a click, and two lines of real information is what makes an entry read as a person rather than a label. Entries also have a resting surface, not just a hover one.

**The entries are a shelf that scrolls, not a row that wraps** — at every width, not as a phone special case. With room, `safe center` centres them and no scrollbar appears; without, it scrolls with the next entry peeking in. Wrapping left an orphan at most widths (3+1 at 1280px, one-per-row and 288px tall on a phone), and the rail's usable width is not even monotonic across breakpoints — `discover col-xl-8` only applies from 1200px up, so 1199px is *wider* than 1280px — so chasing it with media queries does not converge. `flex-start` is declared before `safe center` because plain `center` plus overflow strands the leading entries in browsers without `safe`.

`featured_count` is 4, not 6, so the rail is one clean row at its 70rem measure. Purely a presentation call — it is one config line.

**The entries are deliberately not `creator.card`.** That tile is the *directory's* skin and its fixed vertical composition cannot compress to a rail. The rail borrows the leaderboard's vocabulary instead — page-background rows, neutral-gray hairlines, a gray hover wash, the same 70rem measure that `.dungeonroute_leaderboard` and `.discover_pagination` already share — with the avatar ring picking up `--theme-btn-accent` on hover/focus as the one accent moment. Same creator, different skin, the way a route already renders as a poster, a hero *and* a leaderboard row. `creator.card` itself is untouched, so the directory is unchanged.

**The focus ring is inset, not outset.** `overflow-x: auto` makes the shelf a scrollport on *both* axes, and an outline contributes nothing to the scrollable overflow region — so a positive `outline-offset` is simply clipped: the top 4px of every entry's ring, and the left edge of the first entry's at scroll position 0. Padding on the container does not close it, because the scrollbar gutter sits inside the padding box and eats `padding-bottom` exactly when the shelf overflows. `outline-offset: -2px` draws the ring inside the entry's own border box, where nothing can crop it at any width or scroll position:

![focus ring](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/1769-rail-focus.png)

## Three things caught by screenshotting, not by tests

**Initials state their colour rather than inheriting it.** Each theme's `.theme.<name> a` rule (0,2,1) outweighs a single class on the entry (0,1,0), so `color: inherit` on a child of the entry link resolves to the theme's *link* colour — the initials rendered accent green under darkly and purple under vapor, a second accent competing with the hover ring and low-contrast lettering on the neutral disc. Same trap family as the `bg-body-*` note this MR adds to the `blade-expert` skill.

**A keyboard-only regression, invisible to the whole suite** — the clipped focus ring above. Verified fixed by tabbing to the entry in headless Chrome (real key presses, so `:focus-visible` genuinely applies rather than a scripted `.focus()`): `matchesFocusVisible: true`, computed ring `2px solid rgb(0, 188, 140)`, box inside the container on every side.

**A name clipped by `text-overflow` had no reveal path.** Reshaping into a rail moved the route count into the entry's `title` and dropped the name's own `title` in the same edit, and the CSS comment then documented the intent rather than the shipped markup. The tooltip now carries both, through a `view_creator.featured.entry_title` key so the join stays translatable.

## Backend

`getFeaturedCreators()` and `paginateCreators()` still share `buildListedCreatorsQuery()`, so a creator who opts out of the directory cannot still be featured; there is a test for exactly that.

The one behavioural change is that **`getFeaturedCreators()` is now cached** (`keystoneguru.creators.featured_ttl`, 1 hour). The shared query derives its published route counts with a `GROUP BY` over the whole `dungeon_routes` table, which materialises in full before `LIMIT` can take four rows off it — ~36 ms warm on a 507k-route database — and unlike the hero band the rail renders on *every* page of results, not just the first. The result varies by neither viewer nor dungeon nor page, so there is nothing to key on and no invalidation question. `CacheService::remember()` is a passthrough while caching is disabled, so development and the test suite are unaffected.

The composer binding stays. Its original justification ("three controller methods render the landing") no longer applies, but the pattern still buys the thing that matters: adding the rail to another discover surface is one `@include` that can never silently render empty because someone forgot to pass the data — the same reason `DiscoverSearchComposer` and `DiscoverAffixGroupComposer` exist.

## Verification

**6 feature tests**, all passing — eligibility, directory opt-out honoured on the rail too, limit respected, the rail rendered with both flags on, hidden with `CreatorProfiles` off, and hidden with `DungeonRouteListRework` off (so it cannot leak into the legacy layout it was never styled for). The limit test is mutation-checked: commenting out `->limit()` makes it fail.

**Browser-verified** in headless Chrome under **darkly, lux and vapor**, at **1600px, 1280px and 390px** — one row everywhere — every theme lives in the one class-scoped stylesheet, so swapping the `html` class is a faithful preview.

1280px (scrolls, with the fourth entry peeking) / lux / vapor:

![1280](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/1769-rail-1280.png)
![lux](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/1769-rail-lux.png)
![vapor](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/1769-rail-vapor.png)

Mobile (390px) — the same shelf, 94px:

![mobile](https://raw.githubusercontent.com/RaiderIO/keystone.guru/verification-screenshots/pr/1769-rail-mobile.png)

**PHPStan / php-cs-fixer** clean on the changed files. (Locally PHPStan reports 56 `class.notFound` errors, all in `app/Logic/MDT/IO/MDT2Codec.php` from `spomky-labs/cbor-php` missing in this worktree's vendor dir — pre-existing environment skew, unrelated to this diff.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7ZNExCW4A9FkGuFr74XEr
