### PR TITLE
#3983 Poll combat log runs across key level bands instead of a flat minimum of 10

### DIFF
--- a/app/Console/Commands/CombatLog/PollCombatLogRunsCommand.php
+++ b/app/Console/Commands/CombatLog/PollCombatLogRunsCommand.php
@@ -11,8 +11,10 @@ use App\Models\Dungeon;
 use App\Models\Interfaces\CombatLogCriterionModelInterface;
 use App\Models\Season;
 use App\Service\CombatLog\CombatLogParsingCriteriaServiceInterface;
+use App\Service\CombatLog\CombatLogPollingBandServiceInterface;
 use App\Service\CombatLog\Dtos\CombatLogParsingCriterionCheck;
 use App\Service\CombatLog\Dtos\CombatLogRunContext;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
 use App\Service\RaiderIO\Dtos\SearchAdvancedRun;
 use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
 use App\Service\RaiderIO\RaiderIOApiServiceInterface;
@@ -29,6 +31,7 @@ class PollCombatLogRunsCommand extends Command
 
     public function __construct(
         private readonly CombatLogParsingCriteriaServiceInterface $criteriaService,
+        private readonly CombatLogPollingBandServiceInterface     $bandService,
         private readonly RaiderIOApiServiceInterface              $raiderIOApiService,
         private readonly SeasonServiceInterface                   $seasonService,
     ) {
@@ -48,26 +51,17 @@ class PollCombatLogRunsCommand extends Command
         $combatLogVersion = array_key_last(CombatLogVersion::RETAIL_ALL);
 
         $windowDays      = (int)config('keystoneguru.raider_io.combat_log_polling.completed_at_window_days');
-        $mythicLevelMin  = (int)config('keystoneguru.raider_io.combat_log_polling.mythic_level_min');
         $limit           = (int)config('keystoneguru.raider_io.combat_log_polling.limit');
         $completedAtFrom = Carbon::now()->subDays($windowDays);
 
-        $allModelsByClass      = [];
-        $eligibleModelsByClass = [];
-        $criteriaSummary       = [];
-
-        foreach (array_keys(CombatLogParsingCriterion::VALID_CRITERIA) as $modelClass) {
-            $allModelsByClass[$modelClass]      = $this->criteriaService->getAllModelsForCriteria($modelClass, $season);
-            $eligibleModelsByClass[$modelClass] = $this->criteriaService->getModelsEligibleForPolling($combatLogVersion, $modelClass, $season);
-
-            $shortClass        = class_basename($modelClass);
-            $allCount          = $allModelsByClass[$modelClass]->count();
-            $eligibleCount     = $eligibleModelsByClass[$modelClass]->count();
-            $criteriaSummary[] = sprintf('%s=%d/%d eligible', $shortClass, $eligibleCount, $allCount);
-        }
+        // Only one band is polled per hour: polling all of them every hour would multiply the
+        // number of Raider.IO calls by the band count for no extra coverage.
+        $spreadBand = $this->bandService->getSpreadBandForHour($season, Carbon::now()->hour);
+        $topBand    = $this->bandService->getTopBand($season);
 
         $force = (bool)$this->option('force');
 
+        /** @var array<int, true> $existingRunIds */
         $existingRunIds = $force ? [] : ParsedCombatLog::query()
             ->whereNotNull('run_id')
             ->pluck('run_id')
@@ -75,35 +69,98 @@ class PollCombatLogRunsCommand extends Command
             ->all();
 
         $this->info(sprintf(
-            'combatlog:pollruns — season=%s version=%d window=%dd min_level=%d limit=%d existing_parsed=%d force=%s | %s',
+            'combatlog:pollruns — season=%s version=%d window=%dd limit=%d existing_parsed=%d force=%s | bands=[%s] this_hour=%s top=%s',
             $season->name,
             $combatLogVersion,
             $windowDays,
-            $mythicLevelMin,
             $limit,
             count($existingRunIds),
             $force ? 'yes' : 'no',
-            implode(', ', $criteriaSummary),
+            implode(', ', array_map(strval(...), $this->bandService->getSpreadBands($season))),
+            $spreadBand === null ? 'none' : (string)$spreadBand,
+            (string)$topBand,
         ));
 
-        if (collect($eligibleModelsByClass)->every(fn(Collection $c) => $c->isEmpty())) {
-            $this->warn('combatlog:pollruns — all criteria at threshold, nothing to poll');
-
-            return self::SUCCESS;
-        }
+        $dispatchCounts = [
+            'dispatched'       => 0,
+            'skippedParsed'    => 0,
+            'skippedNoDungeon' => 0,
+        ];
 
         /** @var Collection<int|string, Dungeon> $dungeonsByChallengeModeId */
-        $dungeonsByChallengeModeId = $allModelsByClass[Dungeon::class]->keyBy('challenge_mode_id');
+        $dungeonsByChallengeModeId = $this->criteriaService->getAllModelsForCriteria(Dungeon::class, $season)
+            ->keyBy('challenge_mode_id');
         /** @var Collection<int|string, CharacterClassSpecialization> $allSpecsByBlizzardId */
-        $allSpecsByBlizzardId = $allModelsByClass[CharacterClassSpecialization::class]->keyBy('specialization_id');
+        $allSpecsByBlizzardId = $this->criteriaService->getAllModelsForCriteria(CharacterClassSpecialization::class, $season)
+            ->keyBy('specialization_id');
 
-        $totalDispatched       = 0;
-        $totalSkippedParsed    = 0;
-        $totalSkippedNoDungeon = 0;
+        if ($spreadBand !== null) {
+            $this->pollSpreadBand(
+                $season,
+                $combatLogVersion,
+                $spreadBand,
+                $completedAtFrom,
+                $limit,
+                $dungeonsByChallengeModeId,
+                $allSpecsByBlizzardId,
+                $existingRunIds,
+                $force,
+                $dispatchCounts,
+            );
+        }
+
+        $this->pollTopBand(
+            $season,
+            $combatLogVersion,
+            $topBand,
+            $completedAtFrom,
+            $limit,
+            $dungeonsByChallengeModeId,
+            $allSpecsByBlizzardId,
+            $existingRunIds,
+            $force,
+            $dispatchCounts,
+        );
+
+        $this->info(sprintf(
+            'combatlog:pollruns — done dispatched=%d skipped_parsed=%d skipped_no_dungeon=%d',
+            $dispatchCounts['dispatched'],
+            $dispatchCounts['skippedParsed'],
+            $dispatchCounts['skippedNoDungeon'],
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Polls each dungeon and each spec that still has budget left in this hour's band.
+     *
+     * @param Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
+     * @param Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
+     * @param array<int, true>                                     $existingRunIds
+     * @param array<string, int>                                   $dispatchCounts
+     */
+    private function pollSpreadBand(
+        Season       $season,
+        int          $combatLogVersion,
+        KeyLevelBand $band,
+        Carbon       $completedAtFrom,
+        int          $limit,
+        Collection   $dungeonsByChallengeModeId,
+        Collection   $allSpecsByBlizzardId,
+        array        &        $existingRunIds,
+        bool         $force,
+        array        &        $dispatchCounts,
+    ): void {
+        $criteriaSummary = [];
 
         foreach (array_keys(CombatLogParsingCriterion::VALID_CRITERIA) as $modelClass) {
-            foreach ($eligibleModelsByClass[$modelClass] as $model) {
-                $primaryCheck = new CombatLogParsingCriterionCheck($modelClass, $model->getKey());
+            $eligibleModels = $this->criteriaService->getModelsEligibleForPolling($combatLogVersion, $modelClass, $season, $band);
+
+            $criteriaSummary[] = sprintf('%s=%d eligible', class_basename($modelClass), $eligibleModels->count());
+
+            foreach ($eligibleModels as $model) {
+                $primaryCheck = new CombatLogParsingCriterionCheck($modelClass, $model->getKey(), $band);
 
                 // Re-evaluate before each API call: prior dispatches may have already
                 // recorded enough runs for this criterion via recordParsed().
@@ -111,65 +168,108 @@ class PollCombatLogRunsCommand extends Command
                     continue;
                 }
 
-                $filter   = $this->buildFilterForCriterion($modelClass, $model, $season, $completedAtFrom, $mythicLevelMin, $limit);
+                $filter   = $this->buildFilterForCriterion($modelClass, $model, $season, $band, $completedAtFrom, $limit);
                 $response = $this->raiderIOApiService->searchAdvancedRuns($filter);
 
                 foreach ($response->runs as $run) {
                     if (isset($existingRunIds[$run->id])) {
-                        $totalSkippedParsed++;
+                        $dispatchCounts['skippedParsed']++;
                         continue;
                     }
 
-                    if (!$this->criteriaService->shouldParse($combatLogVersion, [$primaryCheck])) { // @phpstan-ignore booleanNot.alwaysFalse
+                    if (!$this->criteriaService->shouldParse($combatLogVersion, [$primaryCheck])) {
                         break;
                     }
 
-                    $dispatched = $this->dispatchRun($run, $season, $combatLogVersion, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $existingRunIds, $force);
-
-                    if ($dispatched) {
-                        $totalDispatched++;
-                    } else {
-                        $totalSkippedNoDungeon++;
-                    }
+                    $this->dispatchRun($run, $season, $combatLogVersion, $band, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $existingRunIds, $force, $dispatchCounts);
                 }
             }
         }
 
-        $this->info(sprintf(
-            'combatlog:pollruns — done dispatched=%d skipped_parsed=%d skipped_no_dungeon=%d',
-            $totalDispatched,
-            $totalSkippedParsed,
-            $totalSkippedNoDungeon,
-        ));
-
-        return self::SUCCESS;
+        $this->info(sprintf('combatlog:pollruns — band %s | %s', $band, implode(', ', $criteriaSummary)));
     }
 
     /**
-     * @param  Season                                               $season
-     * @param  array<int, true>                                     $existingRunIds
-     * @param  Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
-     * @param  Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
-     * @return bool                                                 Whether the run was dispatched (false means the dungeon was not found)
+     * Polls the highest keys of the season in a single query across all dungeons. These runs are
+     * always dispatched: no budget is consulted, and they are counted against their own band so
+     * they cannot eat into the budgets of the spread bands.
+     *
+     * @param Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
+     * @param Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
+     * @param array<int, true>                                     $existingRunIds
+     * @param array<string, int>                                   $dispatchCounts
+     */
+    private function pollTopBand(
+        Season       $season,
+        int          $combatLogVersion,
+        KeyLevelBand $band,
+        Carbon       $completedAtFrom,
+        int          $limit,
+        Collection   $dungeonsByChallengeModeId,
+        Collection   $allSpecsByBlizzardId,
+        array        &        $existingRunIds,
+        bool         $force,
+        array        &        $dispatchCounts,
+    ): void {
+        $dispatchedBefore = $dispatchCounts['dispatched'];
+
+        $response = $this->raiderIOApiService->searchAdvancedRuns(new SearchAdvancedRunsFilter(
+            dungeon:         null,
+            season:          $season,
+            specs:           collect(),
+            completedAtFrom: $completedAtFrom,
+            completedAtTo:   null,
+            mythicLevelMin:  $band->min,
+            mythicLevelMax:  $band->max,
+            limit:           $limit,
+            offset:          0,
+        ));
+
+        foreach ($response->runs as $run) {
+            if (isset($existingRunIds[$run->id])) {
+                $dispatchCounts['skippedParsed']++;
+                continue;
+            }
+
+            $this->dispatchRun($run, $season, $combatLogVersion, $band, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $existingRunIds, $force, $dispatchCounts);
+        }
+
+        $this->info(sprintf(
+            'combatlog:pollruns — top band %s | available=%s dispatched=%d',
+            $band,
+            $response->total ?? '?',
+            $dispatchCounts['dispatched'] - $dispatchedBefore,
+        ));
+    }
+
+    /**
+     * @param array<int, true>                                     $existingRunIds
+     * @param Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
+     * @param Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
+     * @param array<string, int>                                   $dispatchCounts
      */
     private function dispatchRun(
         SearchAdvancedRun $run,
         Season            $season,
         int               $combatLogVersion,
+        KeyLevelBand      $band,
         Collection        $dungeonsByChallengeModeId,
         Collection        $allSpecsByBlizzardId,
-        array            &             $existingRunIds,
-        bool              $force = false,
-    ): bool {
+        array             &             $existingRunIds,
+        bool              $force,
+        array             &             $dispatchCounts,
+    ): void {
         /** @var ?Dungeon $dungeon */
         $dungeon = $dungeonsByChallengeModeId->get($run->challengeModeId);
 
         if ($dungeon === null) {
-            return false;
+            $dispatchCounts['skippedNoDungeon']++;
+
+            return;
         }
 
-        $dungeonCriterion = new CombatLogParsingCriterionCheck(Dungeon::class, $dungeon->id);
-        $specCriteria     = $this->buildSpecCriteria($run->memberSpecIds, $allSpecsByBlizzardId);
+        $dungeonCriterion = new CombatLogParsingCriterionCheck(Dungeon::class, $dungeon->id, $band);
+        $specCriteria     = $this->buildSpecCriteria($run->memberSpecIds, $allSpecsByBlizzardId, $band);
 
         $this->criteriaService->recordParsed($combatLogVersion, array_merge([$dungeonCriterion], $specCriteria));
 
@@ -180,58 +280,45 @@ class PollCombatLogRunsCommand extends Command
 
         ProcessCombatLogSegments::dispatch($season, $run->id, $combatLogVersion, new CombatLogRunContext($run->mythicLevel, $run->affixes));
 
-        return true;
+        $dispatchCounts['dispatched']++;
     }
 
     /**
-     * @param  class-string                     $modelClass
-     * @param  CombatLogCriterionModelInterface $model
-     * @param  Season                           $season
-     * @param  Carbon                           $completedAtFrom
-     * @param  int                              $mythicLevelMin
-     * @param  int                              $limit
-     * @return SearchAdvancedRunsFilter
+     * @param class-string                     $modelClass
+     * @param CombatLogCriterionModelInterface $model
      */
     private function buildFilterForCriterion(
         string                           $modelClass,
         CombatLogCriterionModelInterface $model,
         Season                           $season,
+        KeyLevelBand                     $band,
         Carbon                           $completedAtFrom,
-        int                              $mythicLevelMin,
         int                              $limit,
     ): SearchAdvancedRunsFilter {
         if ($modelClass === Dungeon::class) {
             /** @var Dungeon $model */
-            return new SearchAdvancedRunsFilter(
-                dungeon:         $model,
-                season:          $season,
-                specs:           collect(),
-                completedAtFrom: $completedAtFrom,
-                completedAtTo:   null,
-                mythicLevelMin:  $mythicLevelMin,
-                limit:           $limit,
-                offset:          0,
-            );
-        }
-
-        if ($modelClass === CharacterClassSpecialization::class) {
-            /** @var CharacterClassSpecialization $model */
+            $dungeon = $model;
+            /** @var Collection<int, CharacterClassSpecialization> $specs */
+            $specs = collect();
+        } elseif ($modelClass === CharacterClassSpecialization::class) {
+            $dungeon = null;
             /** @var Collection<int, CharacterClassSpecialization> $specs */
             $specs = collect([$model]);
-
-            return new SearchAdvancedRunsFilter(
-                dungeon:         null,
-                season:          $season,
-                specs:           $specs,
-                completedAtFrom: $completedAtFrom,
-                completedAtTo:   null,
-                mythicLevelMin:  $mythicLevelMin,
-                limit:           $limit,
-                offset:          0,
-            );
+        } else {
+            throw new \UnexpectedValueException(sprintf('Unknown model class: %s', $modelClass));
         }
 
-        throw new \UnexpectedValueException(sprintf('Unknown model class: %s', $modelClass));
+        return new SearchAdvancedRunsFilter(
+            dungeon:         $dungeon,
+            season:          $season,
+            specs:           $specs,
+            completedAtFrom: $completedAtFrom,
+            completedAtTo:   null,
+            mythicLevelMin:  $band->min,
+            mythicLevelMax:  $band->max,
+            limit:           $limit,
+            offset:          0,
+        );
     }
 
     /**
@@ -239,7 +326,7 @@ class PollCombatLogRunsCommand extends Command
      * @param  Collection<int|string, CharacterClassSpecialization> $specsByBlizzardId
      * @return CombatLogParsingCriterionCheck[]
      */
-    private function buildSpecCriteria(array $memberSpecIds, Collection $specsByBlizzardId): array
+    private function buildSpecCriteria(array $memberSpecIds, Collection $specsByBlizzardId, KeyLevelBand $band): array
     {
         $criteria = [];
 
@@ -248,7 +335,7 @@ class PollCombatLogRunsCommand extends Command
             $spec = $specsByBlizzardId->get($blizzardSpecId);
 
             if ($spec !== null) {
-                $criteria[] = new CombatLogParsingCriterionCheck(CharacterClassSpecialization::class, $spec->id);
+                $criteria[] = new CombatLogParsingCriterionCheck(CharacterClassSpecialization::class, $spec->id, $band);
             }
         }
 

--- a/app/Console/Commands/CombatLog/PollCombatLogRunsCommand.php
+++ b/app/Console/Commands/CombatLog/PollCombatLogRunsCommand.php
@@ -61,20 +61,19 @@ class PollCombatLogRunsCommand extends Command
 
         $force = (bool)$this->option('force');
 
-        /** @var array<int, true> $existingRunIds */
-        $existingRunIds = $force ? [] : ParsedCombatLog::query()
-            ->whereNotNull('run_id')
-            ->pluck('run_id')
-            ->flip()
-            ->all();
+        // Runs that must not be dispatched (again): those already parsed in an earlier invocation,
+        // and those dispatched earlier in this one. Filled in per API response instead of up front -
+        // parsed_combat_logs grows into the many thousands over a season, and every run id we could
+        // care about is already right there in the response we just received.
+        /** @var array<int, true> $knownRunIds */
+        $knownRunIds = [];
 
         $this->info(sprintf(
-            'combatlog:pollruns — season=%s version=%d window=%dd limit=%d existing_parsed=%d force=%s | bands=[%s] this_hour=%s top=%s',
+            'combatlog:pollruns — season=%s version=%d window=%dd limit=%d force=%s | bands=[%s] this_hour=%s top=%s',
             $season->name,
             $combatLogVersion,
             $windowDays,
             $limit,
-            count($existingRunIds),
             $force ? 'yes' : 'no',
             implode(', ', array_map(strval(...), $this->bandService->getSpreadBands($season))),
             $spreadBand === null ? 'none' : (string)$spreadBand,
@@ -103,7 +102,7 @@ class PollCombatLogRunsCommand extends Command
                 $limit,
                 $dungeonsByChallengeModeId,
                 $allSpecsByBlizzardId,
-                $existingRunIds,
+                $knownRunIds,
                 $force,
                 $dispatchCounts,
             );
@@ -117,7 +116,7 @@ class PollCombatLogRunsCommand extends Command
             $limit,
             $dungeonsByChallengeModeId,
             $allSpecsByBlizzardId,
-            $existingRunIds,
+            $knownRunIds,
             $force,
             $dispatchCounts,
         );
@@ -137,7 +136,7 @@ class PollCombatLogRunsCommand extends Command
      *
      * @param Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
      * @param Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
-     * @param array<int, true>                                     $existingRunIds
+     * @param array<int, true>                                     $knownRunIds
      * @param array<string, int>                                   $dispatchCounts
      */
     private function pollSpreadBand(
@@ -148,7 +147,7 @@ class PollCombatLogRunsCommand extends Command
         int          $limit,
         Collection   $dungeonsByChallengeModeId,
         Collection   $allSpecsByBlizzardId,
-        array        &        $existingRunIds,
+        array        &        $knownRunIds,
         bool         $force,
         array        &        $dispatchCounts,
     ): void {
@@ -171,8 +170,10 @@ class PollCombatLogRunsCommand extends Command
                 $filter   = $this->buildFilterForCriterion($modelClass, $model, $season, $band, $completedAtFrom, $limit);
                 $response = $this->raiderIOApiService->searchAdvancedRuns($filter);
 
+                $this->markAlreadyParsedRuns($response->runs, $knownRunIds, $force);
+
                 foreach ($response->runs as $run) {
-                    if (isset($existingRunIds[$run->id])) {
+                    if (isset($knownRunIds[$run->id])) {
                         $dispatchCounts['skippedParsed']++;
                         continue;
                     }
@@ -181,7 +182,7 @@ class PollCombatLogRunsCommand extends Command
                         break;
                     }
 
-                    $this->dispatchRun($run, $season, $combatLogVersion, $band, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $existingRunIds, $force, $dispatchCounts);
+                    $this->dispatchRun($run, $season, $combatLogVersion, $band, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $knownRunIds, $force, $dispatchCounts);
                 }
             }
         }
@@ -196,7 +197,7 @@ class PollCombatLogRunsCommand extends Command
      *
      * @param Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
      * @param Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
-     * @param array<int, true>                                     $existingRunIds
+     * @param array<int, true>                                     $knownRunIds
      * @param array<string, int>                                   $dispatchCounts
      */
     private function pollTopBand(
@@ -207,7 +208,7 @@ class PollCombatLogRunsCommand extends Command
         int          $limit,
         Collection   $dungeonsByChallengeModeId,
         Collection   $allSpecsByBlizzardId,
-        array        &        $existingRunIds,
+        array        &        $knownRunIds,
         bool         $force,
         array        &        $dispatchCounts,
     ): void {
@@ -225,13 +226,15 @@ class PollCombatLogRunsCommand extends Command
             offset:          0,
         ));
 
+        $this->markAlreadyParsedRuns($response->runs, $knownRunIds, $force);
+
         foreach ($response->runs as $run) {
-            if (isset($existingRunIds[$run->id])) {
+            if (isset($knownRunIds[$run->id])) {
                 $dispatchCounts['skippedParsed']++;
                 continue;
             }
 
-            $this->dispatchRun($run, $season, $combatLogVersion, $band, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $existingRunIds, $force, $dispatchCounts);
+            $this->dispatchRun($run, $season, $combatLogVersion, $band, $dungeonsByChallengeModeId, $allSpecsByBlizzardId, $knownRunIds, $force, $dispatchCounts);
         }
 
         $this->info(sprintf(
@@ -243,7 +246,7 @@ class PollCombatLogRunsCommand extends Command
     }
 
     /**
-     * @param array<int, true>                                     $existingRunIds
+     * @param array<int, true>                                     $knownRunIds
      * @param Collection<string|int, Dungeon>                      $dungeonsByChallengeModeId
      * @param Collection<string|int, CharacterClassSpecialization> $allSpecsByBlizzardId
      * @param array<string, int>                                   $dispatchCounts
@@ -255,7 +258,7 @@ class PollCombatLogRunsCommand extends Command
         KeyLevelBand      $band,
         Collection        $dungeonsByChallengeModeId,
         Collection        $allSpecsByBlizzardId,
-        array             &             $existingRunIds,
+        array             &             $knownRunIds,
         bool              $force,
         array             &             $dispatchCounts,
     ): void {
@@ -275,12 +278,46 @@ class PollCombatLogRunsCommand extends Command
 
         if (!$force) {
             ParsedCombatLog::create(['run_id' => $run->id]);
-            $existingRunIds[$run->id] = true;
         }
+
+        // Marked even when forcing: the same run legitimately comes back from several criterion
+        // queries and from the top band, and dispatching it twice in one invocation helps nobody.
+        $knownRunIds[$run->id] = true;
 
         ProcessCombatLogSegments::dispatch($season, $run->id, $combatLogVersion, new CombatLogRunContext($run->mythicLevel, $run->affixes));
 
         $dispatchCounts['dispatched']++;
+    }
+
+    /**
+     * Marks every run in this batch that was already parsed in an earlier invocation. Only the run
+     * ids of this one batch are looked up - bounded by the configured page limit and served by the
+     * unique index on run_id - so the size of parsed_combat_logs never enters into it.
+     *
+     * @param SearchAdvancedRun[] $runs
+     * @param array<int, true>    $knownRunIds
+     */
+    private function markAlreadyParsedRuns(array $runs, array &$knownRunIds, bool $force): void
+    {
+        if ($force) {
+            return;
+        }
+
+        $runIdsToCheck = [];
+
+        foreach ($runs as $run) {
+            if (!isset($knownRunIds[$run->id])) {
+                $runIdsToCheck[] = $run->id;
+            }
+        }
+
+        if ($runIdsToCheck === []) {
+            return;
+        }
+
+        foreach (ParsedCombatLog::query()->whereIn('run_id', $runIdsToCheck)->pluck('run_id') as $runId) {
+            $knownRunIds[(int)$runId] = true;
+        }
     }
 
     /**

--- a/app/Console/Commands/CombatLog/ResolvesCombatLogSearchFilter.php
+++ b/app/Console/Commands/CombatLog/ResolvesCombatLogSearchFilter.php
@@ -34,6 +34,7 @@ trait ResolvesCombatLogSearchFilter
             completedAtFrom: Carbon::now()->subDays((int)$this->option('from-days')),
             completedAtTo:   null,
             mythicLevelMin:  (int)$this->option('min-level'),
+            mythicLevelMax:  null,
             limit:           (int)$this->option('limit'),
             offset:          (int)$this->option('offset'),
         );

--- a/app/Http/Controllers/AdminTools/AdminToolsCombatLogCriteriaController.php
+++ b/app/Http/Controllers/AdminTools/AdminToolsCombatLogCriteriaController.php
@@ -22,6 +22,7 @@ class AdminToolsCombatLogCriteriaController extends Controller
             ->where('date', $today)
             ->orderBy('combat_log_version')
             ->orderBy('model_class')
+            ->orderBy('mythic_level_min')
             ->get();
 
         $modelsById = [];

--- a/app/Models/CombatLog/CombatLogParsingCriterion.php
+++ b/app/Models/CombatLog/CombatLogParsingCriterion.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Carbon;
  * @property int          $combat_log_version
  * @property class-string $model_class
  * @property int          $model_id
+ * @property int          $mythic_level_min
+ * @property int|null     $mythic_level_max
  * @property Carbon       $date
  * @property int          $count
  * @property int          $threshold
@@ -47,10 +49,29 @@ class CombatLogParsingCriterion extends Model
         'combat_log_version',
         'model_class',
         'model_id',
+        'mythic_level_min',
+        'mythic_level_max',
         'date',
         'count',
         'threshold',
     ];
+
+    /**
+     * Whether this row tracks the open ended band of the highest keys of the season. Those runs
+     * are always parsed, so the row is a counter for visibility only - it has no budget and its
+     * threshold is meaningless.
+     */
+    public function isTopBand(): bool
+    {
+        return $this->mythic_level_max === null;
+    }
+
+    public function getBandName(): string
+    {
+        return $this->isTopBand()
+            ? sprintf('%d+', $this->mythic_level_min)
+            : sprintf('%d-%d', $this->mythic_level_min, $this->mythic_level_max);
+    }
 
     protected static function newFactory(): CombatLogParsingCriterionFactory
     {

--- a/app/Models/CombatLog/ParsedCombatLog.php
+++ b/app/Models/CombatLog/ParsedCombatLog.php
@@ -9,12 +9,13 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
 
 /**
- * @property int  $id
- * @property int  $combat_log_path
- * @property bool $extracted_data
+ * @property int         $id
+ * @property string|null $combat_log_path
+ * @property int|null    $run_id          The Raider.IO run this combat log belongs to, written by PollCombatLogRunsCommand.
+ * @property bool        $extracted_data
  *
- * @property Carbon $created_at
- * @property Carbon $updated_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  *
  * @mixin Eloquent
  */

--- a/app/Providers/KeystoneGuruServiceProvider.php
+++ b/app/Providers/KeystoneGuruServiceProvider.php
@@ -62,6 +62,8 @@ use App\Service\CombatLog\CombatLogMappingVersionService;
 use App\Service\CombatLog\CombatLogMappingVersionServiceInterface;
 use App\Service\CombatLog\CombatLogParsingCriteriaService;
 use App\Service\CombatLog\CombatLogParsingCriteriaServiceInterface;
+use App\Service\CombatLog\CombatLogPollingBandService;
+use App\Service\CombatLog\CombatLogPollingBandServiceInterface;
 use App\Service\CombatLog\CombatLogRouteDungeonRouteService;
 use App\Service\CombatLog\CombatLogRouteDungeonRouteServiceInterface;
 use App\Service\CombatLog\CombatLogRouteEnemyFailureService;
@@ -233,6 +235,7 @@ class KeystoneGuruServiceProvider extends ServiceProvider
         $this->app->bind(CombatLogSplitServiceInterface::class, CombatLogSplitService::class);
         $this->app->bind(CombatLogMappingVersionServiceInterface::class, CombatLogMappingVersionService::class);
         $this->app->bind(CombatLogParsingCriteriaServiceInterface::class, CombatLogParsingCriteriaService::class);
+        $this->app->bind(CombatLogPollingBandServiceInterface::class, CombatLogPollingBandService::class);
         $this->app->bind(UserServiceInterface::class, UserService::class);
         $this->app->bind(StructuredLoggingServiceInterface::class, StructuredLoggingService::class);
         $this->app->bind(SpellServiceInterface::class, SpellService::class);

--- a/app/Service/CombatLog/CombatLogParsingCriteriaService.php
+++ b/app/Service/CombatLog/CombatLogParsingCriteriaService.php
@@ -117,17 +117,19 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
             [
                 'mythic_level_max' => $band->max,
                 'count'            => 0,
-                'threshold'        => $this->getDefaultThreshold($criterion->getModelClass(), $band),
+                'threshold'        => $this->getDefaultThreshold($criterion->getModelClass(), $criterion->getModelId(), $band),
             ],
         );
     }
 
     /**
-     * Thresholds are per band: inheriting the most recent threshold of the model class as a whole
-     * would hand every band the budget that was configured for a single one, multiplying the
-     * volume that gets parsed each day by the number of bands.
+     * Thresholds are configured per model per band - that is the granularity of the inputs on the
+     * admin page - so a new row inherits from the same model in the same band, and nothing else.
+     * Inheriting across bands would hand every band the budget that was configured for a single
+     * one; inheriting across models would silently apply one dungeon's raised threshold to every
+     * other dungeon whose row happens to be created later.
      */
-    private function getDefaultThreshold(string $modelClass, KeyLevelBand $band): int
+    private function getDefaultThreshold(string $modelClass, int $modelId, KeyLevelBand $band): int
     {
         if ($band->isTopBand()) {
             return 0;
@@ -135,6 +137,7 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
 
         $lastConfiguredThreshold = CombatLogParsingCriterion::query()
             ->where('model_class', $modelClass)
+            ->where('model_id', $modelId)
             ->where('mythic_level_min', $band->min)
             // Top band rows share this column with whichever spread band starts on the same level
             // once the max key level rises, and they carry a meaningless threshold of 0. Inheriting

--- a/app/Service/CombatLog/CombatLogParsingCriteriaService.php
+++ b/app/Service/CombatLog/CombatLogParsingCriteriaService.php
@@ -8,6 +8,7 @@ use App\Models\Dungeon;
 use App\Models\Interfaces\CombatLogCriterionModelInterface;
 use App\Models\Season;
 use App\Service\CombatLog\Dtos\CombatLogParsingCriterionCheck;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
@@ -21,7 +22,12 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
         $today = Carbon::now()->toDateString();
 
         foreach ($criteria as $criterion) {
-            $row = $this->findOrCreate($combatLogVersion, $criterion->getModelClass(), $criterion->getModelId(), $today);
+            // The top band is always parsed - it has no budget to run out of
+            if ($criterion->getBand()->isTopBand()) {
+                continue;
+            }
+
+            $row = $this->findOrCreate($combatLogVersion, $criterion, $today);
 
             if ($row->count >= $row->threshold) {
                 return false;
@@ -39,7 +45,7 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
         $today = Carbon::now()->toDateString();
 
         foreach ($criteria as $criterion) {
-            $this->findOrCreate($combatLogVersion, $criterion->getModelClass(), $criterion->getModelId(), $today)
+            $this->findOrCreate($combatLogVersion, $criterion, $today)
                 ->increment('count');
         }
     }
@@ -70,14 +76,19 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
         };
     }
 
-    public function getModelsEligibleForPolling(int $combatLogVersion, string $modelClass, Season $season): Collection
+    public function getModelsEligibleForPolling(int $combatLogVersion, string $modelClass, Season $season, KeyLevelBand $band): Collection
     {
         $allModels = $this->getAllModelsForCriteria($modelClass, $season);
+
+        if ($band->isTopBand()) {
+            return $allModels;
+        }
 
         /** @var array<int, true> $atThresholdModelIds */
         $atThresholdModelIds = CombatLogParsingCriterion::query()
             ->where('combat_log_version', $combatLogVersion)
             ->where('model_class', $modelClass)
+            ->where('mythic_level_min', $band->min)
             ->where('date', Carbon::now()->toDateString())
             ->whereColumn('count', '>=', 'threshold')
             ->pluck('model_id')
@@ -88,28 +99,47 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
     }
 
     private function findOrCreate(
-        int    $combatLogVersion,
-        string $modelClass,
-        int    $modelId,
-        string $date,
+        int                            $combatLogVersion,
+        CombatLogParsingCriterionCheck $criterion,
+        string                         $date,
     ): CombatLogParsingCriterion {
+        $band = $criterion->getBand();
+
         /** @var CombatLogParsingCriterion */
         return CombatLogParsingCriterion::query()->firstOrCreate(
             [
                 'combat_log_version' => $combatLogVersion,
-                'model_class'        => $modelClass,
-                'model_id'           => $modelId,
+                'model_class'        => $criterion->getModelClass(),
+                'model_id'           => $criterion->getModelId(),
+                'mythic_level_min'   => $band->min,
                 'date'               => $date,
             ],
-            ['count' => 0, 'threshold' => $this->getDefaultThreshold($modelClass)],
+            [
+                'mythic_level_max' => $band->max,
+                'count'            => 0,
+                'threshold'        => $this->getDefaultThreshold($criterion->getModelClass(), $band),
+            ],
         );
     }
 
-    private function getDefaultThreshold(string $modelClass): int
+    /**
+     * Thresholds are per band: inheriting the most recent threshold of the model class as a whole
+     * would hand every band the budget that was configured for a single one, multiplying the
+     * volume that gets parsed each day by the number of bands.
+     */
+    private function getDefaultThreshold(string $modelClass, KeyLevelBand $band): int
     {
-        return CombatLogParsingCriterion::query()
+        if ($band->isTopBand()) {
+            return 0;
+        }
+
+        $lastConfiguredThreshold = CombatLogParsingCriterion::query()
             ->where('model_class', $modelClass)
+            ->where('mythic_level_min', $band->min)
             ->orderBy('date', 'desc')
-            ->value('threshold') ?? 100;
+            ->value('threshold');
+
+        return $lastConfiguredThreshold
+            ?? (int)config('keystoneguru.raider_io.combat_log_polling.bands.default_threshold');
     }
 }

--- a/app/Service/CombatLog/CombatLogParsingCriteriaService.php
+++ b/app/Service/CombatLog/CombatLogParsingCriteriaService.php
@@ -136,6 +136,10 @@ class CombatLogParsingCriteriaService implements CombatLogParsingCriteriaService
         $lastConfiguredThreshold = CombatLogParsingCriterion::query()
             ->where('model_class', $modelClass)
             ->where('mythic_level_min', $band->min)
+            // Top band rows share this column with whichever spread band starts on the same level
+            // once the max key level rises, and they carry a meaningless threshold of 0. Inheriting
+            // that would leave the new spread band permanently at its budget, day after day.
+            ->whereNotNull('mythic_level_max')
             ->orderBy('date', 'desc')
             ->value('threshold');
 

--- a/app/Service/CombatLog/CombatLogParsingCriteriaServiceInterface.php
+++ b/app/Service/CombatLog/CombatLogParsingCriteriaServiceInterface.php
@@ -6,13 +6,15 @@ use App\Models\CombatLog\CombatLogParsingCriterion;
 use App\Models\Interfaces\CombatLogCriterionModelInterface;
 use App\Models\Season;
 use App\Service\CombatLog\Dtos\CombatLogParsingCriterionCheck;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
 use Illuminate\Support\Collection;
 
 interface CombatLogParsingCriteriaServiceInterface
 {
     /**
      * Returns true if ALL given criteria counts for today are below their configured thresholds
-     * for the given combat log version.
+     * for the given combat log version. Criteria in the top band are always parseable: those runs
+     * bypass the budgets entirely.
      *
      * Note: call recordParsed() immediately when this returns true (at webhook accept time,
      * not after processing) so concurrent requests see updated counts.
@@ -52,12 +54,13 @@ interface CombatLogParsingCriteriaServiceInterface
     public function getAllModelsForCriteria(string $modelClass, Season $season): Collection;
 
     /**
-     * Returns all models from getAllModelsForCriteria() that are still eligible for polling today:
-     * models with no row yet (implicit count = 0) and models with count < threshold.
-     * Models with count >= threshold are excluded.
+     * Returns all models from getAllModelsForCriteria() that are still eligible for polling today
+     * in the given band: models with no row yet for that band (implicit count = 0) and models with
+     * count < threshold. Models with count >= threshold are excluded, and every model is eligible
+     * in the top band.
      *
      * @param  class-string<CombatLogCriterionModelInterface>    $modelClass
      * @return Collection<int, CombatLogCriterionModelInterface>
      */
-    public function getModelsEligibleForPolling(int $combatLogVersion, string $modelClass, Season $season): Collection;
+    public function getModelsEligibleForPolling(int $combatLogVersion, string $modelClass, Season $season, KeyLevelBand $band): Collection;
 }

--- a/app/Service/CombatLog/CombatLogPollingBandService.php
+++ b/app/Service/CombatLog/CombatLogPollingBandService.php
@@ -9,6 +9,7 @@ use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 use Throwable;
 
 class CombatLogPollingBandService implements CombatLogPollingBandServiceInterface
@@ -123,9 +124,15 @@ class CombatLogPollingBandService implements CombatLogPollingBandServiceInterfac
             }
         }
 
-        return $levelMin;
+        // Nothing at all is being played in volume, which cannot be true of a live season. Fail
+        // closed on the ceiling rather than on the minimum level: a top band that starts at the
+        // minimum matches every run there is, and the top band is parsed without any budget.
+        return $ceiling;
     }
 
+    /**
+     * @throws RuntimeException When the upstream run count could not be established.
+     */
     private function isPlayedInVolume(Season $season, int $keyLevel): bool
     {
         $minRuns    = (int)config('keystoneguru.raider_io.combat_log_polling.top_band.min_runs_for_level');
@@ -143,7 +150,13 @@ class CombatLogPollingBandService implements CombatLogPollingBandServiceInterfac
             offset:          0,
         ));
 
-        return ($response->total ?? 0) >= $minRuns;
+        // A malformed or throttled response yields a null total. Reading that as "nobody plays
+        // this level" would walk the probe all the way down and cache the result for a week.
+        if ($response->total === null) {
+            throw new RuntimeException(sprintf('No run count returned for keystone level %d', $keyLevel));
+        }
+
+        return $response->total >= $minRuns;
     }
 
     private function getBandLevelMin(): int

--- a/app/Service/CombatLog/CombatLogPollingBandService.php
+++ b/app/Service/CombatLog/CombatLogPollingBandService.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Service\CombatLog;
+
+use App\Models\Season;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
+use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
+use App\Service\RaiderIO\RaiderIOApiServiceInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class CombatLogPollingBandService implements CombatLogPollingBandServiceInterface
+{
+    private const string MAX_KEY_LEVEL_CACHE_KEY = 'combatlog:pollruns:max_key_level:%d:%s';
+
+    private const string MAX_KEY_LEVEL_LAST_KNOWN_CACHE_KEY = 'combatlog:pollruns:max_key_level_last_known:%d';
+
+    private const int MAX_KEY_LEVEL_LAST_KNOWN_TTL_DAYS = 60;
+
+    public function __construct(
+        private readonly RaiderIOApiServiceInterface $raiderIOApiService,
+    ) {
+    }
+
+    public function getMaxKeyLevel(Season $season): int
+    {
+        $cached = Cache::get($this->getMaxKeyLevelCacheKey($season));
+
+        if (is_int($cached)) {
+            return $cached;
+        }
+
+        try {
+            $maxKeyLevel = $this->probeMaxKeyLevel($season);
+        } catch (Throwable $throwable) {
+            $lastKnown = Cache::get($this->getMaxKeyLevelLastKnownCacheKey($season));
+
+            Log::warning('combatlog:pollruns - probing the max key level failed', [
+                'season'     => $season->id,
+                'last_known' => $lastKnown,
+                'exception'  => $throwable->getMessage(),
+            ]);
+
+            // Fail closed: without a probe result the top band collapses to the probe ceiling,
+            // which matches no runs. Parsing nothing extra beats always parsing everything.
+            return is_int($lastKnown) ? $lastKnown : $this->getProbeLevelCeiling();
+        }
+
+        Cache::put($this->getMaxKeyLevelCacheKey($season), $maxKeyLevel, Carbon::now()->addDays(8));
+        Cache::put(
+            $this->getMaxKeyLevelLastKnownCacheKey($season),
+            $maxKeyLevel,
+            Carbon::now()->addDays(self::MAX_KEY_LEVEL_LAST_KNOWN_TTL_DAYS),
+        );
+
+        return $maxKeyLevel;
+    }
+
+    public function getTopBand(Season $season): KeyLevelBand
+    {
+        $levelsBelowMax = (int)config('keystoneguru.raider_io.combat_log_polling.top_band.levels_below_max');
+
+        return new KeyLevelBand(
+            max($this->getMaxKeyLevel($season) - $levelsBelowMax, $this->getBandLevelMin()),
+            null,
+        );
+    }
+
+    public function getSpreadBands(Season $season): array
+    {
+        $levelMin = $this->getBandLevelMin();
+        $width    = max(1, (int)config('keystoneguru.raider_io.combat_log_polling.bands.width'));
+        $topFloor = $this->getTopBand($season)->min;
+
+        $bands = [];
+
+        for ($min = $levelMin; $min < $topFloor; $min += $width) {
+            $bands[] = new KeyLevelBand($min, min($min + $width - 1, $topFloor - 1));
+        }
+
+        return $bands;
+    }
+
+    public function getSpreadBandForHour(Season $season, int $hour): ?KeyLevelBand
+    {
+        $bands = $this->getSpreadBands($season);
+
+        if ($bands === []) {
+            return null;
+        }
+
+        return $bands[$hour % count($bands)];
+    }
+
+    /**
+     * Walks the keystone levels to find the highest one that is still being played in volume.
+     * Seeded from the previously found level so the common case costs a handful of API calls
+     * instead of walking all the way down from the ceiling.
+     */
+    private function probeMaxKeyLevel(Season $season): int
+    {
+        $levelMin = $this->getBandLevelMin();
+        $ceiling  = $this->getProbeLevelCeiling();
+
+        $lastKnown = Cache::get($this->getMaxKeyLevelLastKnownCacheKey($season));
+        $level     = is_int($lastKnown) ? min(max($lastKnown, $levelMin), $ceiling) : $ceiling;
+
+        if ($this->isPlayedInVolume($season, $level)) {
+            while ($level < $ceiling && $this->isPlayedInVolume($season, $level + 1)) {
+                $level++;
+            }
+
+            return $level;
+        }
+
+        while ($level > $levelMin) {
+            $level--;
+
+            if ($this->isPlayedInVolume($season, $level)) {
+                return $level;
+            }
+        }
+
+        return $levelMin;
+    }
+
+    private function isPlayedInVolume(Season $season, int $keyLevel): bool
+    {
+        $minRuns    = (int)config('keystoneguru.raider_io.combat_log_polling.top_band.min_runs_for_level');
+        $windowDays = (int)config('keystoneguru.raider_io.combat_log_polling.top_band.probe_window_days');
+
+        $response = $this->raiderIOApiService->searchAdvancedRuns(new SearchAdvancedRunsFilter(
+            dungeon:         null,
+            season:          $season,
+            specs:           collect(),
+            completedAtFrom: Carbon::now()->subDays($windowDays),
+            completedAtTo:   null,
+            mythicLevelMin:  $keyLevel,
+            mythicLevelMax:  $keyLevel,
+            limit:           1,
+            offset:          0,
+        ));
+
+        return ($response->total ?? 0) >= $minRuns;
+    }
+
+    private function getBandLevelMin(): int
+    {
+        return (int)config('keystoneguru.raider_io.combat_log_polling.bands.level_min');
+    }
+
+    private function getProbeLevelCeiling(): int
+    {
+        return (int)config('keystoneguru.raider_io.combat_log_polling.top_band.probe_level_ceiling');
+    }
+
+    private function getMaxKeyLevelCacheKey(Season $season): string
+    {
+        $now = Carbon::now();
+
+        return sprintf(self::MAX_KEY_LEVEL_CACHE_KEY, $season->id, sprintf('%d-%d', $now->isoWeekYear, $now->isoWeek));
+    }
+
+    private function getMaxKeyLevelLastKnownCacheKey(Season $season): string
+    {
+        return sprintf(self::MAX_KEY_LEVEL_LAST_KNOWN_CACHE_KEY, $season->id);
+    }
+}

--- a/app/Service/CombatLog/CombatLogPollingBandService.php
+++ b/app/Service/CombatLog/CombatLogPollingBandService.php
@@ -4,24 +4,25 @@ namespace App\Service\CombatLog;
 
 use App\Models\Season;
 use App\Service\CombatLog\Dtos\KeyLevelBand;
+use App\Service\CombatLog\Logging\CombatLogPollingBandServiceLoggingInterface;
 use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
 use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Log;
 use RuntimeException;
 use Throwable;
 
 class CombatLogPollingBandService implements CombatLogPollingBandServiceInterface
 {
-    private const string MAX_KEY_LEVEL_CACHE_KEY = 'combatlog:pollruns:max_key_level:%d:%s';
+    private const string MAX_KEY_LEVEL_CACHE_KEY = 'combatlog:pollruns:max_key_level:%d';
 
     private const string MAX_KEY_LEVEL_LAST_KNOWN_CACHE_KEY = 'combatlog:pollruns:max_key_level_last_known:%d';
 
     private const int MAX_KEY_LEVEL_LAST_KNOWN_TTL_DAYS = 60;
 
     public function __construct(
-        private readonly RaiderIOApiServiceInterface $raiderIOApiService,
+        private readonly RaiderIOApiServiceInterface                 $raiderIOApiService,
+        private readonly CombatLogPollingBandServiceLoggingInterface $log,
     ) {
     }
 
@@ -38,18 +39,23 @@ class CombatLogPollingBandService implements CombatLogPollingBandServiceInterfac
         } catch (Throwable $throwable) {
             $lastKnown = Cache::get($this->getMaxKeyLevelLastKnownCacheKey($season));
 
-            Log::warning('combatlog:pollruns - probing the max key level failed', [
-                'season'     => $season->id,
-                'last_known' => $lastKnown,
-                'exception'  => $throwable->getMessage(),
-            ]);
+            $this->log->getMaxKeyLevelProbeFailed(
+                $season->id,
+                is_int($lastKnown) ? $lastKnown : null,
+                $throwable::class,
+                $throwable->getMessage(),
+            );
 
             // Fail closed: without a probe result the top band collapses to the probe ceiling,
             // which matches no runs. Parsing nothing extra beats always parsing everything.
             return is_int($lastKnown) ? $lastKnown : $this->getProbeLevelCeiling();
         }
 
-        Cache::put($this->getMaxKeyLevelCacheKey($season), $maxKeyLevel, Carbon::now()->addDays(8));
+        $cacheMinutes = $this->getMaxKeyLevelCacheMinutes();
+
+        $this->log->getMaxKeyLevelProbed($season->id, $maxKeyLevel, $cacheMinutes);
+
+        Cache::put($this->getMaxKeyLevelCacheKey($season), $maxKeyLevel, Carbon::now()->addMinutes($cacheMinutes));
         Cache::put(
             $this->getMaxKeyLevelLastKnownCacheKey($season),
             $maxKeyLevel,
@@ -169,11 +175,20 @@ class CombatLogPollingBandService implements CombatLogPollingBandServiceInterfac
         return (int)config('keystoneguru.raider_io.combat_log_polling.top_band.probe_level_ceiling');
     }
 
+    /**
+     * How long a probed max key level stays valid. This must stay short: at the start of a season
+     * everyone begins at the minimum key level and climbs over the following days, so a max cached
+     * for a long time pins the top band's floor near the bottom - and the top band is dispatched
+     * without consulting any budget, so it would parse every run of the season.
+     */
+    private function getMaxKeyLevelCacheMinutes(): int
+    {
+        return max(1, (int)config('keystoneguru.raider_io.combat_log_polling.top_band.max_key_level_cache_minutes'));
+    }
+
     private function getMaxKeyLevelCacheKey(Season $season): string
     {
-        $now = Carbon::now();
-
-        return sprintf(self::MAX_KEY_LEVEL_CACHE_KEY, $season->id, sprintf('%d-%d', $now->isoWeekYear, $now->isoWeek));
+        return sprintf(self::MAX_KEY_LEVEL_CACHE_KEY, $season->id);
     }
 
     private function getMaxKeyLevelLastKnownCacheKey(Season $season): string

--- a/app/Service/CombatLog/CombatLogPollingBandServiceInterface.php
+++ b/app/Service/CombatLog/CombatLogPollingBandServiceInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Service\CombatLog;
+
+use App\Models\Season;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
+
+interface CombatLogPollingBandServiceInterface
+{
+    /**
+     * Returns the highest keystone level that is being played in any meaningful volume this
+     * season, determined by probing Raider.IO and cached for the remainder of the ISO week.
+     *
+     * "Meaningful volume" is deliberately not "any run at all": a handful of record attempts
+     * worldwide would otherwise drag the top band up and shrink it to nothing.
+     */
+    public function getMaxKeyLevel(Season $season): int;
+
+    /**
+     * Returns the open ended band of the highest keys of the season. Runs in this band are always
+     * parsed and never consume a band budget.
+     */
+    public function getTopBand(Season $season): KeyLevelBand;
+
+    /**
+     * Returns the budgeted bands, covering everything from the configured minimum level up to
+     * (but excluding) the top band.
+     *
+     * @return list<KeyLevelBand>
+     */
+    public function getSpreadBands(Season $season): array;
+
+    /**
+     * Returns the single spread band to poll during the given hour of the day. Polling every band
+     * every hour would multiply the number of Raider.IO calls by the band count, so the bands take
+     * turns instead. Null when there are no spread bands at all.
+     */
+    public function getSpreadBandForHour(Season $season, int $hour): ?KeyLevelBand;
+}

--- a/app/Service/CombatLog/Dtos/CombatLogParsingCriterionCheck.php
+++ b/app/Service/CombatLog/Dtos/CombatLogParsingCriterionCheck.php
@@ -5,8 +5,9 @@ namespace App\Service\CombatLog\Dtos;
 class CombatLogParsingCriterionCheck
 {
     public function __construct(
-        private readonly string $modelClass,
-        private readonly int    $modelId,
+        private readonly string       $modelClass,
+        private readonly int          $modelId,
+        private readonly KeyLevelBand $band,
     ) {
     }
 
@@ -18,5 +19,10 @@ class CombatLogParsingCriterionCheck
     public function getModelId(): int
     {
         return $this->modelId;
+    }
+
+    public function getBand(): KeyLevelBand
+    {
+        return $this->band;
     }
 }

--- a/app/Service/CombatLog/Dtos/KeyLevelBand.php
+++ b/app/Service/CombatLog/Dtos/KeyLevelBand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Service\CombatLog\Dtos;
+
+/**
+ * A range of keystone levels that is polled and budgeted as one unit.
+ */
+readonly class KeyLevelBand
+{
+    /**
+     * @param int  $min The lowest keystone level in this band (inclusive).
+     * @param ?int $max The highest keystone level in this band (inclusive). Null means the band is
+     *                  open ended - only the top band is, and it is never budgeted.
+     */
+    public function __construct(
+        public int  $min,
+        public ?int $max,
+    ) {
+    }
+
+    public function isTopBand(): bool
+    {
+        return $this->max === null;
+    }
+
+    public function __toString(): string
+    {
+        return $this->max === null
+            ? sprintf('%d+', $this->min)
+            : sprintf('%d-%d', $this->min, $this->max);
+    }
+}

--- a/app/Service/CombatLog/Logging/CombatLogPollingBandServiceLogging.php
+++ b/app/Service/CombatLog/Logging/CombatLogPollingBandServiceLogging.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Service\CombatLog\Logging;
+
+use App\Logging\Concerns\InteractsWithRollbar;
+use App\Logging\StructuredLogging;
+
+class CombatLogPollingBandServiceLogging extends StructuredLogging implements CombatLogPollingBandServiceLoggingInterface
+{
+    use InteractsWithRollbar;
+
+    /**
+     * The probe has a fallback path (the last known max key level, or the probe ceiling), so this
+     * is a warning and not an error - it must not page anyone through Discord.
+     *
+     * The $exceptionClass and $message parameter names are load-bearing: FingerprintsStructuredErrorsHandler
+     * keys on those literal context keys, so renaming them silently changes Sentry grouping.
+     */
+    public function getMaxKeyLevelProbeFailed(int $seasonId, ?int $lastKnown, string $exceptionClass, string $message): void
+    {
+        $this->warning(__METHOD__, get_defined_vars());
+    }
+
+    public function getMaxKeyLevelProbed(int $seasonId, int $maxKeyLevel, int $cacheMinutes): void
+    {
+        $this->debug(__METHOD__, get_defined_vars());
+    }
+}

--- a/app/Service/CombatLog/Logging/CombatLogPollingBandServiceLoggingInterface.php
+++ b/app/Service/CombatLog/Logging/CombatLogPollingBandServiceLoggingInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Service\CombatLog\Logging;
+
+interface CombatLogPollingBandServiceLoggingInterface
+{
+    public function getMaxKeyLevelProbeFailed(int $seasonId, ?int $lastKnown, string $exceptionClass, string $message): void;
+
+    public function getMaxKeyLevelProbed(int $seasonId, int $maxKeyLevel, int $cacheMinutes): void;
+}

--- a/app/Service/RaiderIO/Dtos/SearchAdvancedRunsFilter.php
+++ b/app/Service/RaiderIO/Dtos/SearchAdvancedRunsFilter.php
@@ -14,6 +14,7 @@ readonly class SearchAdvancedRunsFilter
      * @param ?Dungeon                                      $dungeon        Null means no dungeon restriction (all season dungeons).
      * @param Collection<int, CharacterClassSpecialization> $specs          Specs to filter on. Empty collection means no spec filter.
      * @param int                                           $mythicLevelMin Minimum keystone level.
+     * @param ?int                                          $mythicLevelMax Maximum keystone level. Null means no upper bound.
      * @param int                                           $limit          Maximum number of results per page.
      * @param int                                           $offset         Pagination offset.
      */
@@ -24,6 +25,7 @@ readonly class SearchAdvancedRunsFilter
         public Carbon     $completedAtFrom,
         public ?Carbon    $completedAtTo,
         public int        $mythicLevelMin,
+        public ?int       $mythicLevelMax,
         public int        $limit,
         public int        $offset,
     ) {

--- a/app/Service/RaiderIO/RaiderIOApiService.php
+++ b/app/Service/RaiderIO/RaiderIOApiService.php
@@ -115,19 +115,29 @@ class RaiderIOApiService implements RaiderIOApiServiceInterface
             ->values()
             ->toArray();
 
+        $mythicLevel = ['gte' => $filter->mythicLevelMin];
+
+        if ($filter->mythicLevelMax !== null) {
+            $mythicLevel['lte'] = $filter->mythicLevelMax;
+        }
+
         $params = array_filter([
             'type'         => 'mythic_plus_runs',
             'hasAutoRoute' => [0 => ['eq' => 1]],
             'season'       => [0 => ['eq' => $this->buildSeasonString($filter->season->expansion->shortname, $filter->season->index)]],
-            'mythicLevel'  => [0 => ['gte' => $filter->mythicLevelMin]],
+            'mythicLevel'  => [0 => $mythicLevel],
             'numChests'    => [
                 0 => ['eq' => 1],
                 1 => ['eq' => 2],
                 2 => ['eq' => 3],
             ],
-            'completedAt'   => [0 => $completedAt],
-            'timezone'      => 'UTC',
-            'sort'          => ['hasAutoRoute' => 'desc'],
+            'completedAt' => [0 => $completedAt],
+            'timezone'    => 'UTC',
+            // Sorting on hasAutoRoute is a no-op - it is already filtered to 1 - which leaves the
+            // ordering stable across identical calls. Repeated polls of the same narrow filter then
+            // return the exact same page, and every run on it has already been parsed. Ordering by
+            // recency instead means each poll leads with the runs that appeared since the last one.
+            'sort'          => ['completedAt' => 'desc'],
             'limit'         => $filter->limit,
             'offset'        => $filter->offset,
             'dungeonZoneId' => $dungeonZoneId !== null ? [0 => ['eq' => $dungeonZoneId]] : null,
@@ -156,7 +166,12 @@ class RaiderIOApiService implements RaiderIOApiServiceInterface
                 $runs[] = SearchAdvancedRun::fromArray($match['data']);
             }
 
-            $total = isset($json['total']['value']) ? (int)$json['total']['value'] : null;
+            // An empty result set returns a scalar `"total": 0` instead of `{"value": n}`
+            $total = match (true) {
+                isset($json['total']['value'])     => (int)$json['total']['value'],
+                is_numeric($json['total'] ?? null) => (int)$json['total'],
+                default                            => null,
+            };
 
             return new SearchAdvancedRunsResponse($runs, $total);
         } finally {

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -550,6 +550,13 @@ return [
                 'min_runs_for_level'  => (int)env('COMBAT_LOG_POLLING_TOP_BAND_MIN_RUNS_FOR_LEVEL', 25),
                 'probe_window_days'   => (int)env('COMBAT_LOG_POLLING_TOP_BAND_PROBE_WINDOW_DAYS', 7),
                 'probe_level_ceiling' => (int)env('COMBAT_LOG_POLLING_TOP_BAND_PROBE_LEVEL_CEILING', 40),
+
+                // Kept below the hourly schedule of combatlog:pollruns so the max key level is
+                // re-probed on every run. At the start of a season everyone starts at the minimum
+                // key level and climbs over the following days; a max cached for longer pins the
+                // top band's floor near the bottom, and the top band is dispatched without
+                // consulting any budget - so it would parse every run of the season.
+                'max_key_level_cache_minutes' => (int)env('COMBAT_LOG_POLLING_TOP_BAND_MAX_KEY_LEVEL_CACHE_MINUTES', 50),
             ],
         ],
         'weekly_route' => [

--- a/config/keystoneguru.php
+++ b/config/keystoneguru.php
@@ -532,9 +532,25 @@ return [
         'team_id'            => 2136,
         'combat_log_polling' => [
             'completed_at_window_days' => (int)env('COMBAT_LOG_POLLING_COMPLETED_AT_WINDOW_DAYS', 1),
-            'mythic_level_min'         => (int)env('COMBAT_LOG_POLLING_MYTHIC_LEVEL_MIN', 10),
             'limit'                    => (int)env('COMBAT_LOG_POLLING_LIMIT', 100),
             'download_url'             => env('COMBAT_LOG_POLLING_DOWNLOAD_URL'),
+
+            // Runs are polled in key level bands so that what we parse covers the whole spectrum
+            // instead of the (by far most populous) 10-16 range. One band is polled per hour.
+            'bands' => [
+                'level_min'         => (int)env('COMBAT_LOG_POLLING_BAND_LEVEL_MIN', 2),
+                'width'             => (int)env('COMBAT_LOG_POLLING_BAND_WIDTH', 5),
+                'default_threshold' => (int)env('COMBAT_LOG_POLLING_BAND_DEFAULT_THRESHOLD', 60),
+            ],
+
+            // The highest keys of a season are always parsed, bypassing the band budgets
+            // entirely - those are the runs where players have it all figured out.
+            'top_band' => [
+                'levels_below_max'    => (int)env('COMBAT_LOG_POLLING_TOP_BAND_LEVELS_BELOW_MAX', 2),
+                'min_runs_for_level'  => (int)env('COMBAT_LOG_POLLING_TOP_BAND_MIN_RUNS_FOR_LEVEL', 25),
+                'probe_window_days'   => (int)env('COMBAT_LOG_POLLING_TOP_BAND_PROBE_WINDOW_DAYS', 7),
+                'probe_level_ceiling' => (int)env('COMBAT_LOG_POLLING_TOP_BAND_PROBE_LEVEL_CEILING', 40),
+            ],
         ],
         'weekly_route' => [
             'url'  => 'https://raider.io/weekly-routes',

--- a/database/factories/CombatLog/CombatLogParsingCriterionFactory.php
+++ b/database/factories/CombatLog/CombatLogParsingCriterionFactory.php
@@ -22,10 +22,20 @@ class CombatLogParsingCriterionFactory extends Factory
             'combat_log_version' => CombatLogVersion::RETAIL_12_0_5,
             'model_class'        => Dungeon::class,
             'model_id'           => 1,
+            'mythic_level_min'   => 2,
+            'mythic_level_max'   => 6,
             'date'               => Carbon::now()->toDateString(),
             'count'              => 0,
             'threshold'          => 100,
         ];
+    }
+
+    public function forBand(int $mythicLevelMin, ?int $mythicLevelMax): self
+    {
+        return $this->state([
+            'mythic_level_min' => $mythicLevelMin,
+            'mythic_level_max' => $mythicLevelMax,
+        ]);
     }
 
     public function forDungeon(int $dungeonId, int $combatLogVersion = CombatLogVersion::RETAIL_12_0_5): self

--- a/database/migrations/2026_08_12_120000_add_key_level_band_to_combat_log_parsing_criteria_table.php
+++ b/database/migrations/2026_08_12_120000_add_key_level_band_to_combat_log_parsing_criteria_table.php
@@ -41,6 +41,19 @@ return new class extends Migration {
 
     public function down(): void
     {
+        // After a day of banded polling there are several rows per (version, model_class, model_id,
+        // date) - one per band - so the narrower unique index cannot be restored while they exist.
+        // These rows are daily counters that the poller recreates on demand, so collapsing them to
+        // the single lowest-banded row per key loses nothing that matters.
+        $survivingIds = CombatLogParsingCriterion::query()
+            ->selectRaw('MIN(id) as id')
+            ->groupBy('combat_log_version', 'model_class', 'model_id', 'date')
+            ->pluck('id');
+
+        CombatLogParsingCriterion::query()
+            ->whereNotIn('id', $survivingIds)
+            ->delete();
+
         Schema::table('combat_log_parsing_criteria', function (Blueprint $table) {
             $table->index(['model_class', 'date'], 'clpc_model_class_date_index');
             $table->dropIndex('clpc_model_class_band_date_index');

--- a/database/migrations/2026_08_12_120000_add_key_level_band_to_combat_log_parsing_criteria_table.php
+++ b/database/migrations/2026_08_12_120000_add_key_level_band_to_combat_log_parsing_criteria_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('combat_log_parsing_criteria', function (Blueprint $table) {
+            // The key level band this budget applies to. mythic_level_max is null for the
+            // top band, which is open ended and never budgeted. Pre-existing rows keep 0,
+            // which no longer matches any band the poller asks for and simply goes inert.
+            $table->unsignedInteger('mythic_level_min')->default(0)->after('model_id');
+            $table->unsignedInteger('mythic_level_max')->nullable()->after('mythic_level_min');
+        });
+
+        Schema::table('combat_log_parsing_criteria', function (Blueprint $table) {
+            $table->dropUnique('clpc_version_model_class_model_id_date_unique');
+
+            $table->unique(
+                ['combat_log_version', 'model_class', 'model_id', 'date', 'mythic_level_min'],
+                'clpc_version_class_id_date_band_unique',
+            );
+
+            // Used by getDefaultThreshold(): WHERE model_class = ? AND mythic_level_min = ? ORDER BY date DESC.
+            // Supersedes clpc_model_class_date_index, which it fully covers by prefix.
+            $table->index(['model_class', 'mythic_level_min', 'date'], 'clpc_model_class_band_date_index');
+            $table->dropIndex('clpc_model_class_date_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('combat_log_parsing_criteria', function (Blueprint $table) {
+            $table->index(['model_class', 'date'], 'clpc_model_class_date_index');
+            $table->dropIndex('clpc_model_class_band_date_index');
+
+            $table->dropUnique('clpc_version_class_id_date_band_unique');
+            $table->unique(
+                ['combat_log_version', 'model_class', 'model_id', 'date'],
+                'clpc_version_model_class_model_id_date_unique',
+            );
+        });
+
+        Schema::table('combat_log_parsing_criteria', function (Blueprint $table) {
+            $table->dropColumn(['mythic_level_min', 'mythic_level_max']);
+        });
+    }
+};

--- a/database/migrations/2026_08_12_120000_add_key_level_band_to_combat_log_parsing_criteria_table.php
+++ b/database/migrations/2026_08_12_120000_add_key_level_band_to_combat_log_parsing_criteria_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\CombatLog\CombatLogParsingCriterion;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,6 +16,13 @@ return new class extends Migration {
             $table->unsignedInteger('mythic_level_max')->nullable()->after('mythic_level_min');
         });
 
+        // A null mythic_level_max marks the always-parsed top band, so pre-existing rows must not
+        // be left with one: the admin page would render today's rows as a top band and hide their
+        // threshold inputs until tomorrow's rows are created.
+        CombatLogParsingCriterion::query()
+            ->whereNull('mythic_level_max')
+            ->update(['mythic_level_max' => 0]);
+
         Schema::table('combat_log_parsing_criteria', function (Blueprint $table) {
             $table->dropUnique('clpc_version_model_class_model_id_date_unique');
 
@@ -24,7 +32,8 @@ return new class extends Migration {
             );
 
             // Used by getDefaultThreshold(): WHERE model_class = ? AND mythic_level_min = ? ORDER BY date DESC.
-            // Supersedes clpc_model_class_date_index, which it fully covers by prefix.
+            // Replaces clpc_model_class_date_index, whose lookup it serves by prefix - only the
+            // ordering falls back to a filesort, which this table is far too small to care about.
             $table->index(['model_class', 'mythic_level_min', 'date'], 'clpc_model_class_band_date_index');
             $table->dropIndex('clpc_model_class_date_index');
         });

--- a/lang/en_US/view_admin.php
+++ b/lang/en_US/view_admin.php
@@ -741,6 +741,9 @@ return [
                 'section_class_specs' => 'Class / Specializations',
                 'band'                => 'Key level :band',
                 'band_top'            => 'Key level :band (always parsed)',
+                'band_summary'        => ':fulfilled / :total fulfilled',
+                'band_summary_top'    => ':count parsed',
+                'band_summary_parsed' => ':count / :threshold parsed',
                 'parsed_count'        => ':count parsed',
             ],
             'route' => [

--- a/lang/en_US/view_admin.php
+++ b/lang/en_US/view_admin.php
@@ -739,6 +739,9 @@ return [
                 'version'             => 'Combat log version :version',
                 'section_dungeons'    => 'Dungeons',
                 'section_class_specs' => 'Class / Specializations',
+                'band'                => 'Key level :band',
+                'band_top'            => 'Key level :band (always parsed)',
+                'parsed_count'        => ':count parsed',
             ],
             'route' => [
                 'enemy_failures' => [

--- a/resources/views/admin/tools/combatlog/criteria.blade.php
+++ b/resources/views/admin/tools/combatlog/criteria.blade.php
@@ -38,47 +38,66 @@
                         <?php $modelCriteria = $versionCriteria->where('model_class', $modelClass); ?>
                         @if($modelCriteria->isNotEmpty())
                             <h4 class="mt-3">{{ class_basename($modelClass) }}</h4>
-                            @foreach($modelCriteria as $criterion)
+                            @foreach($modelCriteria->groupBy('mythic_level_min') as $bandCriteria)
                                 @php
-                                    /** @var CombatLogCriterionModelInterface|null $model */
-                                    $model     = $modelsById[$modelClass]->get($criterion->model_id);
-                                    $label     = $model?->getName() ?? sprintf('#%d', $criterion->model_id);
-                                    $imageLink = $model?->getImageLink();
-                                    $pct       = $criterion->threshold > 0 ? min(100, round($criterion->count / $criterion->threshold * 100)) : 0;
+                                    /** @var CombatLogParsingCriterion $firstOfBand */
+                                    $firstOfBand = $bandCriteria->first();
+                                    $isTopBand   = $firstOfBand->isTopBand();
                                 @endphp
-                                <div class="d-flex align-items-center mb-2">
-                                    @if($imageLink !== null)
-                                        <img src="{{ $imageLink }}" alt="{{ $label }}" style="height: 48px; width: auto; object-fit: cover;" class="me-3 rounded flex-shrink-0">
-                                    @endif
-                                    <div class="flex-grow-1">
-                                        <div class="d-flex align-items-center justify-content-between mb-1">
-                                            <span>{{ $label }}</span>
-                                            <div class="d-flex align-items-center ms-3" style="gap: 4px;">
-                                                <small class="text-muted">{{ $criterion->count }} /</small>
-                                                <input
-                                                    type="number"
-                                                    name="thresholds[{{ $criterion->id }}]"
-                                                    value="{{ $criterion->threshold }}"
-                                                    min="1"
-                                                    class="form-control form-control-sm"
-                                                    style="width: 70px;"
-                                                >
+                                <h5 class="mt-3 text-muted">
+                                    {{ $isTopBand
+                                        ? __('view_admin.tools.combatlog.criteria.band_top', ['band' => $firstOfBand->getBandName()])
+                                        : __('view_admin.tools.combatlog.criteria.band', ['band' => $firstOfBand->getBandName()]) }}
+                                </h5>
+                                @foreach($bandCriteria as $criterion)
+                                    @php
+                                        /** @var CombatLogCriterionModelInterface|null $model */
+                                        $model     = $modelsById[$modelClass]->get($criterion->model_id);
+                                        $label     = $model?->getName() ?? sprintf('#%d', $criterion->model_id);
+                                        $imageLink = $model?->getImageLink();
+                                        $pct       = $criterion->threshold > 0 ? min(100, round($criterion->count / $criterion->threshold * 100)) : 0;
+                                    @endphp
+                                    <div class="d-flex align-items-center mb-2">
+                                        @if($imageLink !== null)
+                                            <img src="{{ $imageLink }}" alt="{{ $label }}" style="height: 48px; width: auto; object-fit: cover;" class="me-3 rounded flex-shrink-0">
+                                        @endif
+                                        <div class="flex-grow-1">
+                                            <div class="d-flex align-items-center justify-content-between mb-1">
+                                                <span>{{ $label }}</span>
+                                                <div class="d-flex align-items-center ms-3" style="gap: 4px;">
+                                                    @if($isTopBand)
+                                                        {{-- The top band is always parsed, so it has no threshold to configure --}}
+                                                        <small class="text-muted">{{ __('view_admin.tools.combatlog.criteria.parsed_count', ['count' => $criterion->count]) }}</small>
+                                                    @else
+                                                        <small class="text-muted">{{ $criterion->count }} /</small>
+                                                        <input
+                                                            type="number"
+                                                            name="thresholds[{{ $criterion->id }}]"
+                                                            value="{{ $criterion->threshold }}"
+                                                            min="1"
+                                                            class="form-control form-control-sm"
+                                                            style="width: 70px;"
+                                                        >
+                                                    @endif
+                                                </div>
                                             </div>
-                                        </div>
-                                        <div class="progress">
-                                            <div
-                                                class="progress-bar {{ $criterion->count >= $criterion->threshold ? 'bg-success' : '' }}"
-                                                role="progressbar"
-                                                style="width: {{ $pct }}%;"
-                                                aria-valuenow="{{ $criterion->count }}"
-                                                aria-valuemin="0"
-                                                aria-valuemax="{{ $criterion->threshold }}"
-                                            >
-                                                {{ $pct }}%
-                                            </div>
+                                            @unless($isTopBand)
+                                                <div class="progress">
+                                                    <div
+                                                        class="progress-bar {{ $criterion->count >= $criterion->threshold ? 'bg-success' : '' }}"
+                                                        role="progressbar"
+                                                        style="width: {{ $pct }}%;"
+                                                        aria-valuenow="{{ $criterion->count }}"
+                                                        aria-valuemin="0"
+                                                        aria-valuemax="{{ $criterion->threshold }}"
+                                                    >
+                                                        {{ $pct }}%
+                                                    </div>
+                                                </div>
+                                            @endunless
                                         </div>
                                     </div>
-                                </div>
+                                @endforeach
                             @endforeach
                         @endif
                     @endforeach

--- a/resources/views/admin/tools/combatlog/criteria.blade.php
+++ b/resources/views/admin/tools/combatlog/criteria.blade.php
@@ -7,6 +7,7 @@
     use App\Models\CombatLog\CombatLogParsingCriterion;
     use App\Models\Interfaces\CombatLogCriterionModelInterface;
     use Illuminate\Support\Collection;
+    use Illuminate\Support\Str;
 
     /**
      * @var Collection<int, Collection<int, CombatLogParsingCriterion>>            $criteriaByVersion
@@ -38,67 +39,134 @@
                         <?php $modelCriteria = $versionCriteria->where('model_class', $modelClass); ?>
                         @if($modelCriteria->isNotEmpty())
                             <h4 class="mt-3">{{ class_basename($modelClass) }}</h4>
-                            @foreach($modelCriteria->groupBy('mythic_level_min') as $bandCriteria)
-                                @php
-                                    /** @var CombatLogParsingCriterion $firstOfBand */
-                                    $firstOfBand = $bandCriteria->first();
-                                    $isTopBand   = $firstOfBand->isTopBand();
-                                @endphp
-                                <h5 class="mt-3 text-muted">
-                                    {{ $isTopBand
-                                        ? __('view_admin.tools.combatlog.criteria.band_top', ['band' => $firstOfBand->getBandName()])
-                                        : __('view_admin.tools.combatlog.criteria.band', ['band' => $firstOfBand->getBandName()]) }}
-                                </h5>
-                                @foreach($bandCriteria as $criterion)
+                            {{-- One accordion item per band, all collapsed: with every criterion repeated
+                                 across every band the page is otherwise thousands of pixels tall. The
+                                 header carries the whole overview so it rarely needs expanding. --}}
+                            <div class="accordion mb-3">
+                                @foreach($modelCriteria->groupBy('mythic_level_min') as $bandCriteria)
                                     @php
-                                        /** @var CombatLogCriterionModelInterface|null $model */
-                                        $model     = $modelsById[$modelClass]->get($criterion->model_id);
-                                        $label     = $model?->getName() ?? sprintf('#%d', $criterion->model_id);
-                                        $imageLink = $model?->getImageLink();
-                                        $pct       = $criterion->threshold > 0 ? min(100, round($criterion->count / $criterion->threshold * 100)) : 0;
+                                        /** @var CombatLogParsingCriterion $firstOfBand */
+                                        $firstOfBand = $bandCriteria->first();
+                                        $isTopBand   = $firstOfBand->isTopBand();
+                                        $totalCount  = $bandCriteria->sum('count');
+
+                                        // The top band has no budget - its rows are counters for visibility only,
+                                        // so "fulfilled" is meaningless there and it stays neutral.
+                                        $fulfilled = $isTopBand ? 0 : $bandCriteria->filter(
+                                            fn(CombatLogParsingCriterion $criterion): bool => $criterion->count >= $criterion->threshold
+                                        )->count();
+
+                                        // Both site themes keep Bootstrap's light palette (the theme is a
+                                        // body class, not data-bs-theme), so the subtle background stays light
+                                        // and needs the matching -emphasis text colour to stay readable.
+                                        $headerClass = match (true) {
+                                            $isTopBand                            => 'bg-info-subtle text-info-emphasis',
+                                            $fulfilled === $bandCriteria->count() => 'bg-success-subtle text-success-emphasis',
+                                            default                               => 'bg-warning-subtle text-warning-emphasis',
+                                        };
+
+                                        $collapseId = sprintf(
+                                            'criteria-band-%d-%s-%d',
+                                            $version,
+                                            Str::slug(class_basename($modelClass)),
+                                            $firstOfBand->mythic_level_min,
+                                        );
                                     @endphp
-                                    <div class="d-flex align-items-center mb-2">
-                                        @if($imageLink !== null)
-                                            <img src="{{ $imageLink }}" alt="{{ $label }}" style="height: 48px; width: auto; object-fit: cover;" class="me-3 rounded flex-shrink-0">
-                                        @endif
-                                        <div class="flex-grow-1">
-                                            <div class="d-flex align-items-center justify-content-between mb-1">
-                                                <span>{{ $label }}</span>
-                                                <div class="d-flex align-items-center ms-3" style="gap: 4px;">
+                                    <div class="accordion-item">
+                                        <h5 class="accordion-header mb-0">
+                                            <button
+                                                class="accordion-button collapsed {{ $headerClass }}"
+                                                type="button"
+                                                data-bs-toggle="collapse"
+                                                data-bs-target="#{{ $collapseId }}"
+                                                aria-expanded="false"
+                                                aria-controls="{{ $collapseId }}"
+                                            >
+                                                <span class="d-flex flex-wrap align-items-center w-100 pe-3" style="gap: 12px;">
+                                                    <span class="fw-bold">
+                                                        {{ $isTopBand
+                                                            ? __('view_admin.tools.combatlog.criteria.band_top', ['band' => $firstOfBand->getBandName()])
+                                                            : __('view_admin.tools.combatlog.criteria.band', ['band' => $firstOfBand->getBandName()]) }}
+                                                    </span>
                                                     @if($isTopBand)
-                                                        {{-- The top band is always parsed, so it has no threshold to configure --}}
-                                                        <small class="text-muted">{{ __('view_admin.tools.combatlog.criteria.parsed_count', ['count' => $criterion->count]) }}</small>
+                                                        <span class="badge text-bg-info">
+                                                            {{ __('view_admin.tools.combatlog.criteria.band_summary_top', ['count' => $totalCount]) }}
+                                                        </span>
                                                     @else
-                                                        <small class="text-muted">{{ $criterion->count }} /</small>
-                                                        <input
-                                                            type="number"
-                                                            name="thresholds[{{ $criterion->id }}]"
-                                                            value="{{ $criterion->threshold }}"
-                                                            min="1"
-                                                            class="form-control form-control-sm"
-                                                            style="width: 70px;"
-                                                        >
+                                                        <span class="badge {{ $fulfilled === $bandCriteria->count() ? 'text-bg-success' : 'text-bg-warning' }}">
+                                                            {{ __('view_admin.tools.combatlog.criteria.band_summary', [
+                                                                'fulfilled' => $fulfilled,
+                                                                'total'     => $bandCriteria->count(),
+                                                            ]) }}
+                                                        </span>
+                                                        <span class="small opacity-75">
+                                                            {{ __('view_admin.tools.combatlog.criteria.band_summary_parsed', [
+                                                                'count'     => $totalCount,
+                                                                'threshold' => $bandCriteria->sum('threshold'),
+                                                            ]) }}
+                                                        </span>
                                                     @endif
-                                                </div>
-                                            </div>
-                                            @unless($isTopBand)
-                                                <div class="progress">
-                                                    <div
-                                                        class="progress-bar {{ $criterion->count >= $criterion->threshold ? 'bg-success' : '' }}"
-                                                        role="progressbar"
-                                                        style="width: {{ $pct }}%;"
-                                                        aria-valuenow="{{ $criterion->count }}"
-                                                        aria-valuemin="0"
-                                                        aria-valuemax="{{ $criterion->threshold }}"
-                                                    >
-                                                        {{ $pct }}%
+                                                </span>
+                                            </button>
+                                        </h5>
+                                        {{-- Collapsed only hides the panel, it stays in the DOM - which is what keeps
+                                             the threshold inputs of every band part of the form on submit. --}}
+                                        <div id="{{ $collapseId }}" class="accordion-collapse collapse">
+                                            <div class="accordion-body">
+                                                @foreach($bandCriteria as $criterion)
+                                                    @php
+                                                        /** @var CombatLogCriterionModelInterface|null $model */
+                                                        $model     = $modelsById[$modelClass]->get($criterion->model_id);
+                                                        $label     = $model?->getName() ?? sprintf('#%d', $criterion->model_id);
+                                                        $imageLink = $model?->getImageLink();
+                                                        $pct       = $criterion->threshold > 0 ? min(100, round($criterion->count / $criterion->threshold * 100)) : 0;
+                                                    @endphp
+                                                    <div class="d-flex align-items-center mb-2">
+                                                        @if($imageLink !== null)
+                                                            <img src="{{ $imageLink }}" alt="{{ $label }}" style="height: 48px; width: auto; object-fit: cover;" class="me-3 rounded flex-shrink-0">
+                                                        @endif
+                                                        <div class="flex-grow-1">
+                                                            <div class="d-flex align-items-center justify-content-between mb-1">
+                                                                <span>{{ $label }}</span>
+                                                                <div class="d-flex align-items-center ms-3" style="gap: 4px;">
+                                                                    @if($isTopBand)
+                                                                        {{-- The top band is always parsed, so it has no threshold to configure --}}
+                                                                        <small class="text-muted">{{ __('view_admin.tools.combatlog.criteria.parsed_count', ['count' => $criterion->count]) }}</small>
+                                                                    @else
+                                                                        <small class="text-muted">{{ $criterion->count }} /</small>
+                                                                        <input
+                                                                            type="number"
+                                                                            name="thresholds[{{ $criterion->id }}]"
+                                                                            value="{{ $criterion->threshold }}"
+                                                                            min="1"
+                                                                            class="form-control form-control-sm"
+                                                                            style="width: 70px;"
+                                                                        >
+                                                                    @endif
+                                                                </div>
+                                                            </div>
+                                                            @unless($isTopBand)
+                                                                <div class="progress">
+                                                                    <div
+                                                                        class="progress-bar {{ $criterion->count >= $criterion->threshold ? 'bg-success' : '' }}"
+                                                                        role="progressbar"
+                                                                        style="width: {{ $pct }}%;"
+                                                                        aria-valuenow="{{ $criterion->count }}"
+                                                                        aria-valuemin="0"
+                                                                        aria-valuemax="{{ $criterion->threshold }}"
+                                                                    >
+                                                                        {{ $pct }}%
+                                                                    </div>
+                                                                </div>
+                                                            @endunless
+                                                        </div>
                                                     </div>
-                                                </div>
-                                            @endunless
+                                                @endforeach
+                                            </div>
                                         </div>
                                     </div>
                                 @endforeach
-                            @endforeach
+                            </div>
                         @endif
                     @endforeach
                 </div>

--- a/tests/Feature/App/Service/CombatLog/CombatLogParsingCriteriaServiceTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogParsingCriteriaServiceTest.php
@@ -364,6 +364,38 @@ final class CombatLogParsingCriteriaServiceTest extends PublicTestCase
     }
 
     /**
+     * Thresholds are edited per criterion row on the admin page, so they are per model per band.
+     * Inheriting across models would apply one dungeon's hand-raised threshold to every other
+     * dungeon whose row for that band happens to be created afterwards.
+     */
+    #[Test]
+    public function shouldParse_givenThresholdConfiguredForAnotherModelInSameBand_usesConfiguredDefault(): void
+    {
+        // Arrange - a threshold was raised by hand yesterday, but for a different dungeon
+        $otherDungeonId = 999899;
+        Carbon::setTestNow(Carbon::yesterday());
+        CombatLogParsingCriterion::factory()->forDungeon($otherDungeonId)->forBand(2, 6)->create(['threshold' => 300]);
+        Carbon::setTestNow(null);
+
+        try {
+            // Act
+            $this->service->shouldParse(self::VERSION, $this->defaultCriteria(new KeyLevelBand(2, 6)));
+
+            // Assert
+            $this->assertEquals(
+                (int)config('keystoneguru.raider_io.combat_log_polling.bands.default_threshold'),
+                CombatLogParsingCriterion::query()
+                    ->where('model_id', self::DUNGEON_ID)
+                    ->where('mythic_level_min', 2)
+                    ->where('date', Carbon::now()->toDateString())
+                    ->value('threshold'),
+            );
+        } finally {
+            CombatLogParsingCriterion::query()->where('model_id', $otherDungeonId)->delete();
+        }
+    }
+
+    /**
      * Top band rows carry a meaningless threshold of 0 and share mythic_level_min with whichever
      * spread band starts on that level once the max key level of the season rises. Inheriting that
      * 0 would leave the new spread band at its budget from the moment it is created, every day.

--- a/tests/Feature/App/Service/CombatLog/CombatLogParsingCriteriaServiceTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogParsingCriteriaServiceTest.php
@@ -363,6 +363,34 @@ final class CombatLogParsingCriteriaServiceTest extends PublicTestCase
         );
     }
 
+    /**
+     * Top band rows carry a meaningless threshold of 0 and share mythic_level_min with whichever
+     * spread band starts on that level once the max key level of the season rises. Inheriting that
+     * 0 would leave the new spread band at its budget from the moment it is created, every day.
+     */
+    #[Test]
+    public function shouldParse_givenBandThatUsedToBeTheTopBand_ignoresItsThresholdOfZero(): void
+    {
+        // Arrange — yesterday 22+ was the always-parsed top band
+        Carbon::setTestNow(Carbon::yesterday());
+        CombatLogParsingCriterion::factory()->forDungeon(self::DUNGEON_ID)->forBand(22, null)->create(['threshold' => 0]);
+        Carbon::setTestNow(null);
+
+        // Act — the max key level rose, so today 22-26 is an ordinary budgeted band
+        $result = $this->service->shouldParse(self::VERSION, $this->defaultCriteria(new KeyLevelBand(22, 26)));
+
+        // Assert
+        $this->assertTrue($result);
+        $this->assertEquals(
+            (int)config('keystoneguru.raider_io.combat_log_polling.bands.default_threshold'),
+            CombatLogParsingCriterion::query()
+                ->where('model_id', self::DUNGEON_ID)
+                ->where('mythic_level_min', 22)
+                ->where('date', Carbon::now()->toDateString())
+                ->value('threshold'),
+        );
+    }
+
     #[Test]
     public function getModelsEligibleForPolling_givenDungeonAtThresholdInOtherBand_includesDungeon(): void
     {

--- a/tests/Feature/App/Service/CombatLog/CombatLogParsingCriteriaServiceTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogParsingCriteriaServiceTest.php
@@ -10,6 +10,7 @@ use App\Models\Season;
 use App\Service\CombatLog\CombatLogParsingCriteriaService;
 use App\Service\CombatLog\CombatLogParsingCriteriaServiceInterface;
 use App\Service\CombatLog\Dtos\CombatLogParsingCriterionCheck;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
@@ -49,13 +50,23 @@ final class CombatLogParsingCriteriaServiceTest extends PublicTestCase
     }
 
     /**
+     * The band the factory creates rows in by default.
+     */
+    private function band(): KeyLevelBand
+    {
+        return new KeyLevelBand(2, 6);
+    }
+
+    /**
      * @return array<int, CombatLogParsingCriterionCheck>
      */
-    private function defaultCriteria(): array
+    private function defaultCriteria(?KeyLevelBand $band = null): array
     {
+        $band ??= $this->band();
+
         return [
-            new CombatLogParsingCriterionCheck(Dungeon::class, self::DUNGEON_ID),
-            new CombatLogParsingCriterionCheck(CharacterClassSpecialization::class, self::SPEC_ID),
+            new CombatLogParsingCriterionCheck(Dungeon::class, self::DUNGEON_ID, $band),
+            new CombatLogParsingCriterionCheck(CharacterClassSpecialization::class, self::SPEC_ID, $band),
         ];
     }
 
@@ -216,7 +227,7 @@ final class CombatLogParsingCriteriaServiceTest extends PublicTestCase
                 ->delete();
 
             // Act
-            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season);
+            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season, $this->band());
 
             // Assert — all season dungeons are eligible when no rows exist
             $this->assertNotEmpty($result);
@@ -242,7 +253,7 @@ final class CombatLogParsingCriteriaServiceTest extends PublicTestCase
             CombatLogParsingCriterion::factory()->forDungeon($dungeon->id)->atThreshold()->create();
 
             // Act
-            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season);
+            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season, $this->band());
 
             // Assert — dungeon at threshold is excluded
             $this->assertFalse($result->contains('id', $dungeon->id));
@@ -266,9 +277,131 @@ final class CombatLogParsingCriteriaServiceTest extends PublicTestCase
             CombatLogParsingCriterion::factory()->forDungeon($dungeon->id)->withCount(50)->create();
 
             // Act
-            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season);
+            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season, $this->band());
 
             // Assert — dungeon below threshold is still included
+            $this->assertTrue($result->contains('id', $dungeon->id));
+        } finally {
+            CombatLogParsingCriterion::query()
+                ->where('model_class', Dungeon::class)
+                ->where('model_id', $dungeon->id)
+                ->delete();
+        }
+    }
+
+    #[Test]
+    public function shouldParse_givenOtherBandAtThreshold_returnsTrue(): void
+    {
+        // Arrange — the 2-6 band is full, but we are asking about 7-11
+        CombatLogParsingCriterion::factory()->forDungeon(self::DUNGEON_ID)->forBand(2, 6)->atThreshold()->create();
+        CombatLogParsingCriterion::factory()->forClassSpec(self::SPEC_ID)->forBand(2, 6)->atThreshold()->create();
+
+        // Act
+        $result = $this->service->shouldParse(self::VERSION, $this->defaultCriteria(new KeyLevelBand(7, 11)));
+
+        // Assert — bands hold separate budgets, so a full band cannot block another one
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function shouldParse_givenTopBandCriteriaAtThreshold_returnsTrue(): void
+    {
+        // Arrange
+        CombatLogParsingCriterion::factory()->forDungeon(self::DUNGEON_ID)->forBand(22, null)->atThreshold()->create();
+
+        // Act
+        $result = $this->service->shouldParse(self::VERSION, $this->defaultCriteria(new KeyLevelBand(22, null)));
+
+        // Assert — the top band is always parsed, no matter its count
+        $this->assertTrue($result);
+    }
+
+    #[Test]
+    public function recordParsed_givenTopBandCriteria_leavesSpreadBandCountsUntouched(): void
+    {
+        // Arrange
+        CombatLogParsingCriterion::factory()->forDungeon(self::DUNGEON_ID)->forBand(2, 6)->withCount(10)->create();
+
+        // Act
+        $this->service->recordParsed(self::VERSION, $this->defaultCriteria(new KeyLevelBand(22, null)));
+
+        // Assert — always-parsed runs count into their own row and cannot starve the spread bands
+        $this->assertEquals(10, CombatLogParsingCriterion::query()
+            ->where('model_id', self::DUNGEON_ID)
+            ->where('mythic_level_min', 2)
+            ->value('count'));
+        $this->assertEquals(1, CombatLogParsingCriterion::query()
+            ->where('model_id', self::DUNGEON_ID)
+            ->where('mythic_level_min', 22)
+            ->value('count'));
+    }
+
+    #[Test]
+    public function shouldParse_givenThresholdConfiguredForOtherBand_usesConfiguredDefaultForNewBand(): void
+    {
+        // Arrange — a threshold was raised by hand for the 2-6 band yesterday
+        Carbon::setTestNow(Carbon::yesterday());
+        CombatLogParsingCriterion::factory()->forDungeon(self::DUNGEON_ID)->forBand(2, 6)->create(['threshold' => 300]);
+        Carbon::setTestNow(null);
+
+        // Act — today's rows are created for both bands
+        $this->service->shouldParse(self::VERSION, $this->defaultCriteria(new KeyLevelBand(2, 6)));
+        $this->service->shouldParse(self::VERSION, $this->defaultCriteria(new KeyLevelBand(7, 11)));
+
+        // Assert — 2-6 inherits its own configured threshold, 7-11 falls back to the configured default
+        $this->assertEquals(300, CombatLogParsingCriterion::query()
+            ->where('model_id', self::DUNGEON_ID)
+            ->where('mythic_level_min', 2)
+            ->where('date', Carbon::now()->toDateString())
+            ->value('threshold'));
+        $this->assertEquals(
+            (int)config('keystoneguru.raider_io.combat_log_polling.bands.default_threshold'),
+            CombatLogParsingCriterion::query()
+                ->where('model_id', self::DUNGEON_ID)
+                ->where('mythic_level_min', 7)
+                ->value('threshold'),
+        );
+    }
+
+    #[Test]
+    public function getModelsEligibleForPolling_givenDungeonAtThresholdInOtherBand_includesDungeon(): void
+    {
+        // Arrange
+        $season = Season::query()->has('dungeons')->firstOrFail();
+        /** @var Dungeon $dungeon */
+        $dungeon = $season->dungeons()->firstOrFail();
+
+        try {
+            CombatLogParsingCriterion::factory()->forDungeon($dungeon->id)->forBand(2, 6)->atThreshold()->create();
+
+            // Act
+            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season, new KeyLevelBand(7, 11));
+
+            // Assert — being full in one band says nothing about another
+            $this->assertTrue($result->contains('id', $dungeon->id));
+        } finally {
+            CombatLogParsingCriterion::query()
+                ->where('model_class', Dungeon::class)
+                ->where('model_id', $dungeon->id)
+                ->delete();
+        }
+    }
+
+    #[Test]
+    public function getModelsEligibleForPolling_givenTopBandAndDungeonAtThreshold_includesDungeon(): void
+    {
+        // Arrange
+        $season = Season::query()->has('dungeons')->firstOrFail();
+        /** @var Dungeon $dungeon */
+        $dungeon = $season->dungeons()->firstOrFail();
+
+        try {
+            CombatLogParsingCriterion::factory()->forDungeon($dungeon->id)->forBand(22, null)->atThreshold()->create();
+
+            // Act
+            $result = $this->service->getModelsEligibleForPolling(self::VERSION, Dungeon::class, $season, new KeyLevelBand(22, null));
+
+            // Assert — nothing is ever excluded from the top band
             $this->assertTrue($result->contains('id', $dungeon->id));
         } finally {
             CombatLogParsingCriterion::query()

--- a/tests/Feature/App/Service/CombatLog/CombatLogPollingBandServiceTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogPollingBandServiceTest.php
@@ -114,6 +114,44 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
      * @throws Exception
      */
     #[Test]
+    public function getMaxKeyLevel_givenNoLevelPlayedInVolume_failsClosedOnTheCeiling(): void
+    {
+        // Arrange — cannot happen in a live season, so treat it as a broken probe
+        $service = $this->makeService(fn(int $level): int => 0);
+
+        // Act
+        $result = $service->getMaxKeyLevel($this->season);
+
+        // Assert — falling back to the minimum level would make the top band match every run there
+        // is, and the top band is dispatched without consulting any budget
+        $this->assertSame(self::PROBE_CEILING, $result);
+    }
+
+    /**
+     * A throttled or malformed response has no run count. Counting that as "nobody plays this
+     * level" walks the probe all the way to the bottom and caches the result for a week.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function getMaxKeyLevel_givenUnreadableRunCount_failsClosedInsteadOfWalkingDown(): void
+    {
+        // Arrange
+        $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+        $raiderIOApiService->method('searchAdvancedRuns')->willReturn(new SearchAdvancedRunsResponse([], null));
+        $service = new CombatLogPollingBandService($raiderIOApiService);
+
+        // Act
+        $result = $service->getMaxKeyLevel($this->season);
+
+        // Assert
+        $this->assertSame(self::PROBE_CEILING, $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
     public function getMaxKeyLevel_givenPriorResultCached_doesNotProbeAgain(): void
     {
         // Arrange
@@ -218,8 +256,8 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
     #[Test]
     public function getSpreadBandForHour_givenNoRoomBelowTheTopBand_returnsNull(): void
     {
-        // Arrange — nothing is played in volume, so the top band floor sits at the minimum level
-        $service = $this->makeService(fn(int $level): int => 0);
+        // Arrange — a max of 3 puts the top band floor at the minimum level, leaving no room below
+        $service = $this->makeService(fn(int $level): int => $level <= 3 ? 300 : 0);
 
         // Act
         $result = $service->getSpreadBandForHour($this->season, 0);

--- a/tests/Feature/App/Service/CombatLog/CombatLogPollingBandServiceTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogPollingBandServiceTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Tests\Feature\App\Service\CombatLog;
+
+use App\Models\Season;
+use App\Service\CombatLog\CombatLogPollingBandService;
+use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
+use App\Service\RaiderIO\Dtos\SearchAdvancedRunsResponse;
+use App\Service\RaiderIO\RaiderIOApiServiceInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Exception;
+use RuntimeException;
+use Tests\TestCases\PublicTestCase;
+
+#[Group('CombatLog')]
+#[Group('CombatLogPollingBandService')]
+final class CombatLogPollingBandServiceTest extends PublicTestCase
+{
+    private const int LEVEL_MIN     = 2;
+    private const int BAND_WIDTH    = 5;
+    private const int PROBE_CEILING = 40;
+    private const int MIN_RUNS      = 25;
+
+    private Season $season;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->season = Season::query()->firstOrFail();
+
+        config([
+            'keystoneguru.raider_io.combat_log_polling.bands.level_min'              => self::LEVEL_MIN,
+            'keystoneguru.raider_io.combat_log_polling.bands.width'                  => self::BAND_WIDTH,
+            'keystoneguru.raider_io.combat_log_polling.top_band.levels_below_max'    => 2,
+            'keystoneguru.raider_io.combat_log_polling.top_band.min_runs_for_level'  => self::MIN_RUNS,
+            'keystoneguru.raider_io.combat_log_polling.top_band.probe_window_days'   => 7,
+            'keystoneguru.raider_io.combat_log_polling.top_band.probe_level_ceiling' => self::PROBE_CEILING,
+        ]);
+
+        $this->forgetCaches();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        $this->forgetCaches();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getMaxKeyLevel_givenOnlyLowLevelsPlayedInVolume_returnsHighestLevelWithVolume(): void
+    {
+        // Arrange — 24 is the highest level anyone is really running
+        $service = $this->makeService(fn(int $level): int => $level <= 24 ? 300 : 0);
+
+        // Act
+        $result = $service->getMaxKeyLevel($this->season);
+
+        // Assert
+        $this->assertSame(24, $result);
+    }
+
+    /**
+     * A handful of world-record attempts must not drag the max key level up: doing so shrinks the
+     * always-parsed top band to almost nothing.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function getMaxKeyLevel_givenHandfulOfRunsAboveTheNoiseFloor_ignoresThem(): void
+    {
+        // Arrange — 4 runs exist at 25, far below the noise floor, while 24 is played in volume
+        $service = $this->makeService(fn(int $level): int => match (true) {
+            $level <= 24  => 292,
+            $level === 25 => 4,
+            default       => 0,
+        });
+
+        // Act
+        $result = $service->getMaxKeyLevel($this->season);
+
+        // Assert
+        $this->assertSame(24, $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getMaxKeyLevel_givenProbeFails_failsClosedInsteadOfParsingEverything(): void
+    {
+        // Arrange
+        $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+        $raiderIOApiService->method('searchAdvancedRuns')->willThrowException(new RuntimeException('upstream down'));
+        $service = new CombatLogPollingBandService($raiderIOApiService);
+
+        // Act
+        $result = $service->getMaxKeyLevel($this->season);
+
+        // Assert — the ceiling matches no runs at all, which beats always parsing every key
+        $this->assertSame(self::PROBE_CEILING, $result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getMaxKeyLevel_givenPriorResultCached_doesNotProbeAgain(): void
+    {
+        // Arrange
+        $probeCount = 0;
+        $service    = $this->makeService(function (int $level) use (&$probeCount): int {
+            $probeCount++;
+
+            return $level <= 24 ? 300 : 0;
+        });
+        $service->getMaxKeyLevel($this->season);
+        $probesForFirstCall = $probeCount;
+
+        // Act
+        $result = $service->getMaxKeyLevel($this->season);
+
+        // Assert
+        $this->assertSame(24, $result);
+        $this->assertSame($probesForFirstCall, $probeCount);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getTopBand_givenMaxKeyLevel_startsTwoLevelsBelowIt(): void
+    {
+        // Arrange
+        $service = $this->makeService(fn(int $level): int => $level <= 24 ? 300 : 0);
+
+        // Act
+        $result = $service->getTopBand($this->season);
+
+        // Assert
+        $this->assertSame(22, $result->min);
+        $this->assertNull($result->max);
+        $this->assertTrue($result->isTopBand());
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getSpreadBands_givenTopBandFloor_coversEveryLevelBelowItWithoutOverlap(): void
+    {
+        // Arrange
+        $service = $this->makeService(fn(int $level): int => $level <= 24 ? 300 : 0);
+
+        // Act
+        $result = $service->getSpreadBands($this->season);
+
+        // Assert
+        $this->assertSame(
+            ['2-6', '7-11', '12-16', '17-21'],
+            array_map(strval(...), $result),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getSpreadBands_givenTopBandFloorMidBand_clampsLastBandToTheFloor(): void
+    {
+        // Arrange — max 21 puts the top band floor at 19, halfway through the 17-21 band
+        $service = $this->makeService(fn(int $level): int => $level <= 21 ? 300 : 0);
+
+        // Act
+        $result = $service->getSpreadBands($this->season);
+
+        // Assert — no spread band may reach into the always-parsed top band
+        $this->assertSame(
+            ['2-6', '7-11', '12-16', '17-18'],
+            array_map(strval(...), $result),
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getSpreadBandForHour_givenConsecutiveHours_rotatesThroughEveryBand(): void
+    {
+        // Arrange
+        $service = $this->makeService(fn(int $level): int => $level <= 24 ? 300 : 0);
+
+        // Act
+        $bandsByHour = array_map(
+            fn(int $hour): string => (string)$service->getSpreadBandForHour($this->season, $hour),
+            range(0, 8),
+        );
+
+        // Assert — 4 bands, each polled once every 4 hours
+        $this->assertSame(
+            ['2-6', '7-11', '12-16', '17-21', '2-6', '7-11', '12-16', '17-21', '2-6'],
+            $bandsByHour,
+        );
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function getSpreadBandForHour_givenNoRoomBelowTheTopBand_returnsNull(): void
+    {
+        // Arrange — nothing is played in volume, so the top band floor sits at the minimum level
+        $service = $this->makeService(fn(int $level): int => 0);
+
+        // Act
+        $result = $service->getSpreadBandForHour($this->season, 0);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @param  callable(int): int $runCountForLevel
+     * @throws Exception
+     */
+    private function makeService(callable $runCountForLevel): CombatLogPollingBandService
+    {
+        $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+        $raiderIOApiService->method('searchAdvancedRuns')->willReturnCallback(
+            function (SearchAdvancedRunsFilter $filter) use ($runCountForLevel): SearchAdvancedRunsResponse {
+                // The probe asks about exactly one level at a time
+                $this->assertSame($filter->mythicLevelMin, $filter->mythicLevelMax);
+
+                return new SearchAdvancedRunsResponse([], $runCountForLevel($filter->mythicLevelMin));
+            },
+        );
+
+        return new CombatLogPollingBandService($raiderIOApiService);
+    }
+
+    private function forgetCaches(): void
+    {
+        $now = Carbon::now();
+
+        Cache::forget(sprintf(
+            'combatlog:pollruns:max_key_level:%d:%s',
+            $this->season->id,
+            sprintf('%d-%d', $now->isoWeekYear, $now->isoWeek),
+        ));
+        Cache::forget(sprintf('combatlog:pollruns:max_key_level_last_known:%d', $this->season->id));
+    }
+}

--- a/tests/Feature/App/Service/CombatLog/CombatLogPollingBandServiceTest.php
+++ b/tests/Feature/App/Service/CombatLog/CombatLogPollingBandServiceTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
 use RuntimeException;
+use Tests\Fixtures\LoggingFixtures;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('CombatLog')]
@@ -23,6 +24,7 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
     private const int BAND_WIDTH    = 5;
     private const int PROBE_CEILING = 40;
     private const int MIN_RUNS      = 25;
+    private const int CACHE_MINUTES = 50;
 
     private Season $season;
 
@@ -34,12 +36,13 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
         $this->season = Season::query()->firstOrFail();
 
         config([
-            'keystoneguru.raider_io.combat_log_polling.bands.level_min'              => self::LEVEL_MIN,
-            'keystoneguru.raider_io.combat_log_polling.bands.width'                  => self::BAND_WIDTH,
-            'keystoneguru.raider_io.combat_log_polling.top_band.levels_below_max'    => 2,
-            'keystoneguru.raider_io.combat_log_polling.top_band.min_runs_for_level'  => self::MIN_RUNS,
-            'keystoneguru.raider_io.combat_log_polling.top_band.probe_window_days'   => 7,
-            'keystoneguru.raider_io.combat_log_polling.top_band.probe_level_ceiling' => self::PROBE_CEILING,
+            'keystoneguru.raider_io.combat_log_polling.bands.level_min'                      => self::LEVEL_MIN,
+            'keystoneguru.raider_io.combat_log_polling.bands.width'                          => self::BAND_WIDTH,
+            'keystoneguru.raider_io.combat_log_polling.top_band.levels_below_max'            => 2,
+            'keystoneguru.raider_io.combat_log_polling.top_band.min_runs_for_level'          => self::MIN_RUNS,
+            'keystoneguru.raider_io.combat_log_polling.top_band.probe_window_days'           => 7,
+            'keystoneguru.raider_io.combat_log_polling.top_band.probe_level_ceiling'         => self::PROBE_CEILING,
+            'keystoneguru.raider_io.combat_log_polling.top_band.max_key_level_cache_minutes' => self::CACHE_MINUTES,
         ]);
 
         $this->forgetCaches();
@@ -101,7 +104,7 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
         // Arrange
         $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
         $raiderIOApiService->method('searchAdvancedRuns')->willThrowException(new RuntimeException('upstream down'));
-        $service = new CombatLogPollingBandService($raiderIOApiService);
+        $service = new CombatLogPollingBandService($raiderIOApiService, LoggingFixtures::createCombatLogPollingBandServiceLogging($this));
 
         // Act
         $result = $service->getMaxKeyLevel($this->season);
@@ -139,7 +142,7 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
         // Arrange
         $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
         $raiderIOApiService->method('searchAdvancedRuns')->willReturn(new SearchAdvancedRunsResponse([], null));
-        $service = new CombatLogPollingBandService($raiderIOApiService);
+        $service = new CombatLogPollingBandService($raiderIOApiService, LoggingFixtures::createCombatLogPollingBandServiceLogging($this));
 
         // Act
         $result = $service->getMaxKeyLevel($this->season);
@@ -170,6 +173,35 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
         // Assert
         $this->assertSame(24, $result);
         $this->assertSame($probesForFirstCall, $probeCount);
+    }
+
+    /**
+     * At the start of a season everybody starts at the minimum key level and climbs from there. If
+     * the probed max were cached for days, the top band's floor would stay pinned near the bottom -
+     * and since the top band is dispatched without consulting any budget, that means parsing every
+     * run of the season instead of a spread of them.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function getMaxKeyLevel_givenTheMaxClimbsEarlyInASeason_reprobesWithinTheHour(): void
+    {
+        // Arrange - the first day of the season, where nobody is past a +3 yet
+        Carbon::setTestNow(Carbon::create(2026, 3, 4, 12));
+        $highestPlayedLevel = 3;
+        $service            = $this->makeService(function (int $level) use (&$highestPlayedLevel): int {
+            return $level <= $highestPlayedLevel ? 300 : 0;
+        });
+
+        $this->assertSame(3, $service->getMaxKeyLevel($this->season));
+
+        // Act - the raiders have caught up by the time the next hourly run comes around
+        $highestPlayedLevel = 14;
+        Carbon::setTestNow(Carbon::now()->addMinutes(self::CACHE_MINUTES + 1));
+
+        // Assert - the cached max did not survive into the next scheduled run of combatlog:pollruns
+        $this->assertSame(14, $service->getMaxKeyLevel($this->season));
+        $this->assertSame(12, $service->getTopBand($this->season)->min);
     }
 
     /**
@@ -282,18 +314,12 @@ final class CombatLogPollingBandServiceTest extends PublicTestCase
             },
         );
 
-        return new CombatLogPollingBandService($raiderIOApiService);
+        return new CombatLogPollingBandService($raiderIOApiService, LoggingFixtures::createCombatLogPollingBandServiceLogging($this));
     }
 
     private function forgetCaches(): void
     {
-        $now = Carbon::now();
-
-        Cache::forget(sprintf(
-            'combatlog:pollruns:max_key_level:%d:%s',
-            $this->season->id,
-            sprintf('%d-%d', $now->isoWeekYear, $now->isoWeek),
-        ));
+        Cache::forget(sprintf('combatlog:pollruns:max_key_level:%d', $this->season->id));
         Cache::forget(sprintf('combatlog:pollruns:max_key_level_last_known:%d', $this->season->id));
     }
 }

--- a/tests/Feature/App/Service/RaiderIO/RaiderIOApiServiceTest.php
+++ b/tests/Feature/App/Service/RaiderIO/RaiderIOApiServiceTest.php
@@ -6,10 +6,12 @@ use App\Models\Expansion;
 use App\Models\Season;
 use App\Service\Coordinates\CoordinatesServiceInterface;
 use App\Service\RaiderIO\Dtos\CombatLogSegmentsResponse;
+use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
 use App\Service\RaiderIO\Logging\RaiderIOApiServiceLoggingInterface;
 use App\Service\RaiderIO\RaiderIOApiService;
 use App\Service\Season\SeasonAffixGroupServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
@@ -145,6 +147,113 @@ final class RaiderIOApiServiceTest extends PublicTestCase
 
         // Assert
         $this->assertNull($result);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function searchAdvancedRuns_givenBandedFilter_boundsMythicLevelOnBothSides(): void
+    {
+        // Arrange
+        $capturedUrl = null;
+        $service     = $this->makeService(function (string $url) use (&$capturedUrl): string {
+            $capturedUrl = $url;
+
+            return json_encode(['total' => ['value' => 1231], 'matches' => []]);
+        });
+
+        // Act
+        $result = $service->searchAdvancedRuns($this->makeSearchFilter(2, 6));
+
+        // Assert
+        $decodedUrl = urldecode((string)$capturedUrl);
+        $this->assertStringContainsString('mythicLevel[0][gte]=2', $decodedUrl);
+        $this->assertStringContainsString('mythicLevel[0][lte]=6', $decodedUrl);
+        $this->assertSame(1231, $result->total);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function searchAdvancedRuns_givenOpenEndedFilter_omitsUpperBound(): void
+    {
+        // Arrange
+        $capturedUrl = null;
+        $service     = $this->makeService(function (string $url) use (&$capturedUrl): string {
+            $capturedUrl = $url;
+
+            return json_encode(['total' => ['value' => 542], 'matches' => []]);
+        });
+
+        // Act
+        $service->searchAdvancedRuns($this->makeSearchFilter(22, null));
+
+        // Assert
+        $decodedUrl = urldecode((string)$capturedUrl);
+        $this->assertStringContainsString('mythicLevel[0][gte]=22', $decodedUrl);
+        $this->assertStringNotContainsString('mythicLevel[0][lte]', $decodedUrl);
+    }
+
+    /**
+     * The upstream API returns `"total": {"value": n}` for a non-empty result set, but a plain
+     * scalar `"total": 0` when nothing matches. Reading only the object shape reports "unknown"
+     * for an empty band, which is the one answer the top band probe has to be able to trust.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function searchAdvancedRuns_givenEmptyResultSet_readsScalarTotalAsZero(): void
+    {
+        // Arrange
+        $service = $this->makeService(fn(): string => json_encode(['total' => 0, 'matches' => []]));
+
+        // Act
+        $result = $service->searchAdvancedRuns($this->makeSearchFilter(26, 26));
+
+        // Assert
+        $this->assertSame(0, $result->total);
+        $this->assertEmpty($result->runs);
+    }
+
+    /**
+     * Sorting on anything stable hands every repeated poll of the same filter the exact same page,
+     * by which time every run on it has already been parsed.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function searchAdvancedRuns_givenAnyFilter_sortsByRecency(): void
+    {
+        // Arrange
+        $capturedUrl = null;
+        $service     = $this->makeService(function (string $url) use (&$capturedUrl): string {
+            $capturedUrl = $url;
+
+            return json_encode(['total' => 0, 'matches' => []]);
+        });
+
+        // Act
+        $service->searchAdvancedRuns($this->makeSearchFilter(2, 6));
+
+        // Assert
+        $this->assertStringContainsString('sort[completedAt]=desc', urldecode((string)$capturedUrl));
+    }
+
+    private function makeSearchFilter(int $mythicLevelMin, ?int $mythicLevelMax): SearchAdvancedRunsFilter
+    {
+        return new SearchAdvancedRunsFilter(
+            dungeon:         null,
+            season:          $this->makeSeason(),
+            specs:           collect(),
+            completedAtFrom: Carbon::now()->subDay(),
+            completedAtTo:   null,
+            mythicLevelMin:  $mythicLevelMin,
+            mythicLevelMax:  $mythicLevelMax,
+            limit:           100,
+            offset:          0,
+        );
     }
 
     /**

--- a/tests/Feature/App/Service/RaiderIO/RaiderIOKeystoneGuruApiServiceTest.php
+++ b/tests/Feature/App/Service/RaiderIO/RaiderIOKeystoneGuruApiServiceTest.php
@@ -52,6 +52,7 @@ final class RaiderIOKeystoneGuruApiServiceTest extends PublicTestCase
             completedAtFrom: Carbon::now(),
             completedAtTo:   null,
             mythicLevelMin:  0,
+            mythicLevelMax:  null,
             limit:           10,
             offset:          0,
         );

--- a/tests/Feature/Console/Commands/CombatLog/PollCombatLogRunsCommandTest.php
+++ b/tests/Feature/Console/Commands/CombatLog/PollCombatLogRunsCommandTest.php
@@ -8,14 +8,20 @@ use App\Models\CombatLog\ParsedCombatLog;
 use App\Models\Dungeon;
 use App\Models\Season;
 use App\Service\CombatLog\CombatLogParsingCriteriaServiceInterface;
+use App\Service\CombatLog\CombatLogPollingBandServiceInterface;
+use App\Service\CombatLog\Dtos\CombatLogParsingCriterionCheck;
+use App\Service\CombatLog\Dtos\KeyLevelBand;
 use App\Service\RaiderIO\Dtos\SearchAdvancedRun;
+use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
 use App\Service\RaiderIO\Dtos\SearchAdvancedRunsResponse;
 use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
+use PHPUnit\Framework\MockObject\MockObject;
 use Tests\TestCases\PublicTestCase;
 
 #[Group('Console')]
@@ -28,6 +34,16 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
 
     private Season $season;
 
+    private KeyLevelBand $spreadBand;
+
+    private KeyLevelBand $topBand;
+
+    /** @var array<int, int> */
+    private array $capturedMythicLevelMins = [];
+
+    /** @var array<int, int|null> */
+    private array $capturedMythicLevelMaxes = [];
+
     /**
      * @throws Exception
      */
@@ -36,13 +52,21 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
     {
         parent::setUp();
 
-        $this->dungeon = Dungeon::query()->whereNotNull('challenge_mode_id')->first();
-        $this->spec    = CharacterClassSpecialization::query()->first();
-        $this->season  = Season::query()->first();
+        $this->dungeon    = Dungeon::query()->whereNotNull('challenge_mode_id')->first();
+        $this->spec       = CharacterClassSpecialization::query()->first();
+        $this->season     = Season::query()->first();
+        $this->spreadBand = new KeyLevelBand(12, 16);
+        $this->topBand    = new KeyLevelBand(22, null);
 
         $seasonService = $this->createMockPublic(SeasonServiceInterface::class);
         $seasonService->method('getCurrentSeason')->willReturn($this->season);
         app()->instance(SeasonServiceInterface::class, $seasonService);
+
+        $bandService = $this->createMockPublic(CombatLogPollingBandServiceInterface::class);
+        $bandService->method('getSpreadBands')->willReturn([$this->spreadBand]);
+        $bandService->method('getSpreadBandForHour')->willReturn($this->spreadBand);
+        $bandService->method('getTopBand')->willReturn($this->topBand);
+        app()->instance(CombatLogPollingBandServiceInterface::class, $bandService);
     }
 
     /**
@@ -56,29 +80,12 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
 
         $run = $this->makeRun(1001, $this->dungeon->challenge_mode_id);
 
-        $criteriaService = $this->createMockPublic(CombatLogParsingCriteriaServiceInterface::class);
-        $criteriaService->method('getAllModelsForCriteria')->willReturnCallback(
-            fn(string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => CharacterClassSpecialization::query()->get(),
-                default                             => collect(),
-            },
-        );
-        $criteriaService->method('getModelsEligibleForPolling')->willReturnCallback(
-            fn(int $version, string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => collect(),
-                default                             => collect(),
-            },
-        );
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
         $criteriaService->method('shouldParse')->willReturn(true);
         $criteriaService->expects($this->once())->method('recordParsed');
         app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
 
-        $raiderIOService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
-        $raiderIOService->expects($this->once())->method('searchAdvancedRuns')
-            ->willReturn(new SearchAdvancedRunsResponse([$run], 1));
-        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOService);
+        $this->mockRaiderIOApiService(spreadRuns: [$run]);
 
         try {
             // Act
@@ -103,29 +110,12 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
         $runId = 9001;
         $run   = $this->makeRun($runId, $this->dungeon->challenge_mode_id);
 
-        $criteriaService = $this->createMockPublic(CombatLogParsingCriteriaServiceInterface::class);
-        $criteriaService->method('getAllModelsForCriteria')->willReturnCallback(
-            fn(string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => CharacterClassSpecialization::query()->get(),
-                default                             => collect(),
-            },
-        );
-        $criteriaService->method('getModelsEligibleForPolling')->willReturnCallback(
-            fn(int $version, string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => collect(),
-                default                             => collect(),
-            },
-        );
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
         $criteriaService->method('shouldParse')->willReturn(true);
         $criteriaService->expects($this->never())->method('recordParsed');
         app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
 
-        $raiderIOService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
-        $raiderIOService->expects($this->once())->method('searchAdvancedRuns')
-            ->willReturn(new SearchAdvancedRunsResponse([$run], 1));
-        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOService);
+        $this->mockRaiderIOApiService(spreadRuns: [$run]);
 
         try {
             ParsedCombatLog::create(['run_id' => $runId]);
@@ -151,29 +141,12 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
 
         $run = $this->makeRun(2001, $this->dungeon->challenge_mode_id, [$this->spec->specialization_id]);
 
-        $criteriaService = $this->createMockPublic(CombatLogParsingCriteriaServiceInterface::class);
-        $criteriaService->method('getAllModelsForCriteria')->willReturnCallback(
-            fn(string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => CharacterClassSpecialization::query()->get(),
-                default                             => collect(),
-            },
-        );
-        $criteriaService->method('getModelsEligibleForPolling')->willReturnCallback(
-            fn(int $version, string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect(),
-                CharacterClassSpecialization::class => collect([$this->spec]),
-                default                             => collect(),
-            },
-        );
+        $criteriaService = $this->makeCriteriaService(eligibleSpecs: collect([$this->spec]));
         $criteriaService->method('shouldParse')->willReturn(true);
         $criteriaService->expects($this->once())->method('recordParsed');
         app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
 
-        $raiderIOService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
-        $raiderIOService->expects($this->once())->method('searchAdvancedRuns')
-            ->willReturn(new SearchAdvancedRunsResponse([$run], 1));
-        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOService);
+        $this->mockRaiderIOApiService(spreadRuns: [$run]);
 
         try {
             // Act
@@ -195,16 +168,12 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
         // Arrange
         Bus::fake();
 
-        $criteriaService = $this->createMockPublic(CombatLogParsingCriteriaServiceInterface::class);
-        $criteriaService->method('getAllModelsForCriteria')->willReturn(collect());
-        $criteriaService->method('getModelsEligibleForPolling')->willReturn(collect());
+        $criteriaService = $this->makeCriteriaService();
         $criteriaService->expects($this->never())->method('shouldParse');
         $criteriaService->expects($this->never())->method('recordParsed');
         app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
 
-        $raiderIOService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
-        $raiderIOService->expects($this->never())->method('searchAdvancedRuns');
-        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOService);
+        $this->mockRaiderIOApiService();
 
         // Act
         $this->artisan('combatlog:pollruns')->assertSuccessful();
@@ -225,30 +194,13 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
         $run1 = $this->makeRun(3001, $this->dungeon->challenge_mode_id);
         $run2 = $this->makeRun(3002, $this->dungeon->challenge_mode_id);
 
-        $criteriaService = $this->createMockPublic(CombatLogParsingCriteriaServiceInterface::class);
-        $criteriaService->method('getAllModelsForCriteria')->willReturnCallback(
-            fn(string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => CharacterClassSpecialization::query()->get(),
-                default                             => collect(),
-            },
-        );
-        $criteriaService->method('getModelsEligibleForPolling')->willReturnCallback(
-            fn(int $version, string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => collect(),
-                default                             => collect(),
-            },
-        );
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
         // Pre-check passes, but inner check fails after first run is processed
         $criteriaService->method('shouldParse')->willReturnOnConsecutiveCalls(true, true, false);
         $criteriaService->expects($this->once())->method('recordParsed');
         app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
 
-        $raiderIOService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
-        $raiderIOService->expects($this->once())->method('searchAdvancedRuns')
-            ->willReturn(new SearchAdvancedRunsResponse([$run1, $run2], 2));
-        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOService);
+        $this->mockRaiderIOApiService(spreadRuns: [$run1, $run2]);
 
         try {
             // Act
@@ -270,6 +222,127 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
         // Arrange
         Bus::fake();
 
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        // Pre-check fails immediately — criterion was filled by an earlier dispatch
+        $criteriaService->method('shouldParse')->willReturn(false);
+        $criteriaService->expects($this->never())->method('recordParsed');
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService();
+
+        // Act
+        $this->artisan('combatlog:pollruns')->assertSuccessful();
+
+        // Assert — the only call left is the top band one, which never consults a budget
+        Bus::assertNotDispatched(ProcessCombatLogSegments::class);
+        $this->assertSame([$this->topBand->min], $this->capturedMythicLevelMins);
+    }
+
+    /**
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenThisHoursBand_queriesRaiderIOForThatBandOnly(): void
+    {
+        // Arrange
+        Bus::fake();
+
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        $criteriaService->method('shouldParse')->willReturn(true);
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService();
+
+        // Act
+        $this->artisan('combatlog:pollruns')->assertSuccessful();
+
+        // Assert — one call for this hour's spread band, one for the top band
+        $this->assertSame([$this->spreadBand->min, $this->topBand->min], $this->capturedMythicLevelMins);
+        $this->assertSame([$this->spreadBand->max, null], $this->capturedMythicLevelMaxes);
+    }
+
+    /**
+     * The whole point of the top band: those runs are parsed no matter how full the day's budgets
+     * already are.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenTopBandRunAndExhaustedBudgets_dispatchesRunAnyway(): void
+    {
+        // Arrange
+        Bus::fake();
+
+        $run = $this->makeRun(4001, $this->dungeon->challenge_mode_id, mythicLevel: 23);
+
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        $criteriaService->method('shouldParse')->willReturn(false);
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService(topRuns: [$run]);
+
+        try {
+            // Act
+            $this->artisan('combatlog:pollruns')->assertSuccessful();
+
+            // Assert
+            Bus::assertDispatchedTimes(ProcessCombatLogSegments::class, 1);
+        } finally {
+            ParsedCombatLog::query()->where('run_id', $run->id)->delete();
+        }
+    }
+
+    /**
+     * Counting an always-parsed run against the spread bands would let the top band eat the budget
+     * of the very bands it is supposed to leave alone.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenTopBandRun_recordsItAgainstTheTopBandOnly(): void
+    {
+        // Arrange
+        Bus::fake();
+
+        $run = $this->makeRun(4002, $this->dungeon->challenge_mode_id, mythicLevel: 23);
+
+        /** @var array<int, CombatLogParsingCriterionCheck> $recordedCriteria */
+        $recordedCriteria = [];
+
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        $criteriaService->method('shouldParse')->willReturn(false);
+        $criteriaService->method('recordParsed')->willReturnCallback(
+            function (int $version, array $criteria) use (&$recordedCriteria): void {
+                $recordedCriteria = array_merge($recordedCriteria, $criteria);
+            },
+        );
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService(topRuns: [$run]);
+
+        try {
+            // Act
+            $this->artisan('combatlog:pollruns')->assertSuccessful();
+
+            // Assert
+            $this->assertNotEmpty($recordedCriteria);
+            foreach ($recordedCriteria as $criterion) {
+                $this->assertTrue($criterion->getBand()->isTopBand());
+                $this->assertSame($this->topBand->min, $criterion->getBand()->min);
+            }
+        } finally {
+            ParsedCombatLog::query()->where('run_id', $run->id)->delete();
+        }
+    }
+
+    /**
+     * @param  Collection<int, Dungeon>|null                       $eligibleDungeons
+     * @param  Collection<int, CharacterClassSpecialization>|null  $eligibleSpecs
+     * @throws Exception
+     * @return MockObject&CombatLogParsingCriteriaServiceInterface
+     */
+    private function makeCriteriaService(?Collection $eligibleDungeons = null, ?Collection $eligibleSpecs = null): MockObject
+    {
         $criteriaService = $this->createMockPublic(CombatLogParsingCriteriaServiceInterface::class);
         $criteriaService->method('getAllModelsForCriteria')->willReturnCallback(
             fn(string $modelClass) => match ($modelClass) {
@@ -280,38 +353,54 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
         );
         $criteriaService->method('getModelsEligibleForPolling')->willReturnCallback(
             fn(int $version, string $modelClass) => match ($modelClass) {
-                Dungeon::class                      => collect([$this->dungeon]),
-                CharacterClassSpecialization::class => collect(),
+                Dungeon::class                      => $eligibleDungeons ?? collect(),
+                CharacterClassSpecialization::class => $eligibleSpecs ?? collect(),
                 default                             => collect(),
             },
         );
-        // Pre-check fails immediately — criterion was filled by an earlier dispatch
-        $criteriaService->method('shouldParse')->willReturn(false);
-        $criteriaService->expects($this->never())->method('recordParsed');
-        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
 
-        $raiderIOService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
-        $raiderIOService->expects($this->never())->method('searchAdvancedRuns');
-        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOService);
+        return $criteriaService;
+    }
 
-        // Act
-        $this->artisan('combatlog:pollruns')->assertSuccessful();
+    /**
+     * @param  SearchAdvancedRun[] $spreadRuns
+     * @param  SearchAdvancedRun[] $topRuns
+     * @throws Exception
+     */
+    private function mockRaiderIOApiService(array $spreadRuns = [], array $topRuns = []): void
+    {
+        $this->capturedMythicLevelMins  = [];
+        $this->capturedMythicLevelMaxes = [];
 
-        // Assert
-        Bus::assertNotDispatched(ProcessCombatLogSegments::class);
+        $raiderIOApiService = $this->createMockPublic(RaiderIOApiServiceInterface::class);
+        $raiderIOApiService->method('searchAdvancedRuns')->willReturnCallback(
+            function (SearchAdvancedRunsFilter $filter) use ($spreadRuns, $topRuns): SearchAdvancedRunsResponse {
+                $this->capturedMythicLevelMins[]  = $filter->mythicLevelMin;
+                $this->capturedMythicLevelMaxes[] = $filter->mythicLevelMax;
+
+                $runs = $filter->mythicLevelMax === null ? $topRuns : $spreadRuns;
+
+                return new SearchAdvancedRunsResponse($runs, count($runs));
+            },
+        );
+        app()->instance(RaiderIOApiServiceInterface::class, $raiderIOApiService);
     }
 
     /**
      * @param array<int, int> $memberSpecIds
      */
-    private function makeRun(int $id, int $challengeModeId, array $memberSpecIds = [66, 70, 105, 250, 269]): SearchAdvancedRun
-    {
+    private function makeRun(
+        int   $id,
+        int   $challengeModeId,
+        array $memberSpecIds = [66, 70, 105, 250, 269],
+        int   $mythicLevel = 14,
+    ): SearchAdvancedRun {
         return new SearchAdvancedRun(
             id:              $id,
             challengeModeId: $challengeModeId,
             dungeonZoneId:   $this->dungeon->zone_id ?? 0,
             memberSpecIds:   $memberSpecIds,
-            mythicLevel:     10,
+            mythicLevel:     $mythicLevel,
             affixes:         [],
         );
     }

--- a/tests/Feature/Console/Commands/CombatLog/PollCombatLogRunsCommandTest.php
+++ b/tests/Feature/Console/Commands/CombatLog/PollCombatLogRunsCommandTest.php
@@ -371,6 +371,47 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
     }
 
     /**
+     * --force deliberately re-queues runs that were parsed before, but re-queuing the same run
+     * twice within one invocation is never what is wanted - and it must not insert a second row
+     * against the unique index either.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenForceAndARunInMultipleBands_dispatchesItOnceAndInsertsNothing(): void
+    {
+        // Arrange
+        Bus::fake();
+
+        $run = $this->makeRun(5003, $this->dungeon->challenge_mode_id, mythicLevel: 23);
+
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        $criteriaService->method('shouldParse')->willReturn(true);
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService(spreadRuns: [$run], topRuns: [$run]);
+
+        $selects = 0;
+        DB::connection('combatlog')->listen(function (QueryExecuted $query) use (&$selects): void {
+            if (str_contains($query->sql, 'parsed_combat_logs') && str_starts_with($query->sql, 'select')) {
+                $selects++;
+            }
+        });
+
+        try {
+            // Act
+            $this->artisan('combatlog:pollruns', ['--force' => true])->assertSuccessful();
+
+            // Assert - forcing bypasses the already-parsed bookkeeping entirely
+            Bus::assertDispatchedTimes(ProcessCombatLogSegments::class, 1);
+            $this->assertSame(0, $selects);
+            $this->assertSame(0, ParsedCombatLog::query()->where('run_id', $run->id)->count());
+        } finally {
+            ParsedCombatLog::query()->where('run_id', $run->id)->delete();
+        }
+    }
+
+    /**
      * parsed_combat_logs grows into the many thousands of rows over a season, so the already-parsed
      * check must never load the table - it looks up only the run ids of the batch it just received.
      *

--- a/tests/Feature/Console/Commands/CombatLog/PollCombatLogRunsCommandTest.php
+++ b/tests/Feature/Console/Commands/CombatLog/PollCombatLogRunsCommandTest.php
@@ -16,8 +16,10 @@ use App\Service\RaiderIO\Dtos\SearchAdvancedRunsFilter;
 use App\Service\RaiderIO\Dtos\SearchAdvancedRunsResponse;
 use App\Service\RaiderIO\RaiderIOApiServiceInterface;
 use App\Service\Season\SeasonServiceInterface;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\Exception;
@@ -329,6 +331,81 @@ final class PollCombatLogRunsCommandTest extends PublicTestCase
             foreach ($recordedCriteria as $criterion) {
                 $this->assertTrue($criterion->getBand()->isTopBand());
                 $this->assertSame($this->topBand->min, $criterion->getBand()->min);
+            }
+        } finally {
+            ParsedCombatLog::query()->where('run_id', $run->id)->delete();
+        }
+    }
+
+    /**
+     * The same run legitimately comes back from several criterion queries and again from the top
+     * band. Dispatching it more than once wastes a parse, and inserting it twice trips the unique
+     * index on parsed_combat_logs.run_id.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenSameRunReturnedByMultipleBands_dispatchesItOnce(): void
+    {
+        // Arrange
+        Bus::fake();
+
+        $run = $this->makeRun(5001, $this->dungeon->challenge_mode_id, mythicLevel: 23);
+
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        $criteriaService->method('shouldParse')->willReturn(true);
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService(spreadRuns: [$run], topRuns: [$run]);
+
+        try {
+            // Act
+            $this->artisan('combatlog:pollruns')->assertSuccessful();
+
+            // Assert
+            Bus::assertDispatchedTimes(ProcessCombatLogSegments::class, 1);
+            $this->assertSame(1, ParsedCombatLog::query()->where('run_id', $run->id)->count());
+        } finally {
+            ParsedCombatLog::query()->where('run_id', $run->id)->delete();
+        }
+    }
+
+    /**
+     * parsed_combat_logs grows into the many thousands of rows over a season, so the already-parsed
+     * check must never load the table - it looks up only the run ids of the batch it just received.
+     *
+     * @throws Exception
+     */
+    #[Test]
+    public function handle_givenRunsReturned_looksUpOnlyTheRunIdsOfThatBatch(): void
+    {
+        // Arrange
+        Bus::fake();
+
+        $run = $this->makeRun(5002, $this->dungeon->challenge_mode_id);
+
+        $criteriaService = $this->makeCriteriaService(eligibleDungeons: collect([$this->dungeon]));
+        $criteriaService->method('shouldParse')->willReturn(true);
+        app()->instance(CombatLogParsingCriteriaServiceInterface::class, $criteriaService);
+
+        $this->mockRaiderIOApiService(spreadRuns: [$run]);
+
+        /** @var string[] $selects */
+        $selects = [];
+        DB::connection('combatlog')->listen(function (QueryExecuted $query) use (&$selects): void {
+            if (str_contains($query->sql, 'parsed_combat_logs') && str_starts_with($query->sql, 'select')) {
+                $selects[] = $query->sql;
+            }
+        });
+
+        try {
+            // Act
+            $this->artisan('combatlog:pollruns')->assertSuccessful();
+
+            // Assert - every read of the table is scoped to the run ids of a single response
+            $this->assertNotEmpty($selects);
+            foreach ($selects as $sql) {
+                $this->assertStringContainsString('`run_id` in (', $sql);
             }
         } finally {
             ParsedCombatLog::query()->where('run_id', $run->id)->delete();

--- a/tests/Feature/Controller/AdminTools/AdminToolsCombatLogCriteriaControllerTest.php
+++ b/tests/Feature/Controller/AdminTools/AdminToolsCombatLogCriteriaControllerTest.php
@@ -32,6 +32,67 @@ final class AdminToolsCombatLogCriteriaControllerTest extends PublicTestCase
         $response->assertOk();
     }
 
+    /**
+     * Every criterion is repeated once per band, so without collapsing the page runs to thousands
+     * of pixels. The header must carry enough to judge a band without expanding it.
+     */
+    #[Test]
+    public function criteria_givenBandsWithAndWithoutEveryCriterionFulfilled_rendersCollapsedAccordionPerBand(): void
+    {
+        // Arrange
+        $fulfilled   = CombatLogParsingCriterion::factory()->forDungeon(999901)->forBand(90, 94)->atThreshold()->create();
+        $unfulfilled = CombatLogParsingCriterion::factory()->forDungeon(999902)->forBand(95, 99)->withCount(1)->create();
+
+        try {
+            // Act
+            $response = $this->get(route('admin.tools.combatlog.criteria.view'));
+
+            // Assert
+            $response->assertOk();
+            $content = $response->getContent();
+
+            // Both bands are their own accordion item, and both start collapsed
+            $this->assertStringContainsString('id="criteria-band-' . $fulfilled->combat_log_version . '-dungeon-90"', $content);
+            $this->assertStringContainsString('id="criteria-band-' . $unfulfilled->combat_log_version . '-dungeon-95"', $content);
+            $this->assertSame(
+                substr_count($content, 'class="accordion-item"'),
+                substr_count($content, 'accordion-button collapsed'),
+            );
+            $this->assertStringNotContainsString('accordion-collapse collapse show', $content);
+
+            // The at-a-glance status: green when the whole band is fulfilled, orange when it is not
+            $this->assertStringContainsString('bg-success-subtle', $content);
+            $this->assertStringContainsString('bg-warning-subtle', $content);
+        } finally {
+            $fulfilled->delete();
+            $unfulfilled->delete();
+        }
+    }
+
+    /**
+     * A collapsed Bootstrap panel is hidden, not removed - which is the only reason the thresholds
+     * of every band still submit. Rendering panel contents lazily would silently drop them.
+     */
+    #[Test]
+    public function updatethresholds_givenACriterionInACollapsedBand_savesTheNewThreshold(): void
+    {
+        // Arrange
+        $criterion = CombatLogParsingCriterion::factory()->forDungeon(999903)->forBand(12, 16)->create();
+
+        try {
+            // Act
+            $response = $this->post(route('admin.tools.combatlog.criteria.thresholds'), [
+                'thresholds' => [$criterion->id => 42],
+            ]);
+
+            // Assert
+            $response->assertRedirect(route('admin.tools.combatlog.criteria.view'));
+            $this->assertSame(42, $criterion->fresh()->threshold);
+        } finally {
+            $criterion->delete();
+        }
+    }
+
     #[Test]
     public function criteriareset_givenExistingCountsForToday_resetsCountsToZero(): void
     {

--- a/tests/Fixtures/LoggingFixtures.php
+++ b/tests/Fixtures/LoggingFixtures.php
@@ -6,6 +6,7 @@ use App\Service\AffixGroup\Logging\AffixGroupEaseTierServiceLoggingInterface;
 use App\Service\Cache\Logging\CacheServiceLoggingInterface;
 use App\Service\Cloudflare\Logging\CloudflareServiceLoggingInterface;
 use App\Service\CombatLog\Logging\CombatLogDungeonRouteServiceLoggingInterface;
+use App\Service\CombatLog\Logging\CombatLogPollingBandServiceLoggingInterface;
 use App\Service\CombatLog\Logging\CombatLogServiceLoggingInterface;
 use App\Service\CombatLogEvent\Logging\CombatLogEventServiceLoggingInterface;
 use App\Service\DungeonRoute\Logging\DungeonRouteSaveServiceLoggingInterface;
@@ -54,6 +55,15 @@ class LoggingFixtures
         PublicTestCase $testCase,
     ): MockObject|CombatLogDungeonRouteServiceLoggingInterface {
         return $testCase->createMockPublic(CombatLogDungeonRouteServiceLoggingInterface::class);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public static function createCombatLogPollingBandServiceLogging(
+        PublicTestCase $testCase,
+    ): MockObject|CombatLogPollingBandServiceLoggingInterface {
+        return $testCase->createMockPublic(CombatLogPollingBandServiceLoggingInterface::class);
     }
 
     /**


### PR DESCRIPTION
:robot:

Closes #3983

## What this changes

`combatlog:pollruns` asked Raider.IO for every run at level 10 and up, so what got parsed was
whatever the 10-16 range happened to produce — by far the most populous part of the ladder. For the
NPC Compendium the key level of an observation carries no meaning of its own, but the behaviour of
the players in the run does: low keys reveal whether anything was even attempted, high keys only
ever show the thing that works. Coverage of the whole spectrum is what is worth having, so this
does **not** store the key level anywhere — it only changes which runs get sampled.

- **5-wide bands, one per hour on rotation.** `2-6`, `7-11`, `12-16`, `17-21` at the moment.
  Rotating keeps the API call volume exactly where it was (~48/hour) instead of multiplying it by
  the band count.
- **A budget per (criterion, band).** The band is part of the `combat_log_parsing_criteria` key, so
  no band can spend another's. Default 60 per band per dungeon/spec — the same ~2,400 runs/day the
  current 300-per-criterion setting produces.
- **The top band is always parsed.** Everything from `max_key_level - 2` upwards bypasses the
  budgets entirely, in a single all-dungeons query per hour. It counts into its own criterion rows
  so it cannot starve the bands below it.
- **The max key level is probed weekly** by walking `total` down from a ceiling, with a noise floor
  of 25 runs over 7 days so a handful of world-record attempts cannot drag it up. Cached per
  season + ISO week; no scheduled command needed.

## Measured supply this season (yesterday, full UTC day)

| band | runs/day | per dungeon |
|---|---|---|
| 2-6 | 1,231 | 154 |
| 7-11 | 7,667 | 958 |
| 12-16 | 7,929 | 991 |
| 17-21 | 2,205 | 276 |
| 22+ | 542 | 68 |

Every band sustains a 60/day per-dungeon budget. Probing live from the branch resolves to
`max=24`, top band `22+`, spread bands `2-6, 7-11, 12-16, 17-21` — about 540 always-parsed runs a
day on top of the budgeted ~2,400.

## Two traps this had to avoid

- **Threshold inheritance.** `getDefaultThreshold()` resolved the threshold per *model class*, so
  adding a band dimension would have handed all 5 bands the 300 currently configured on production
  — a nominal 12,000 runs/day. It now resolves per (class, band), which also keeps a hand-edited
  threshold sticky for the band it was edited on.
- **Sort stability.** The search sorted on `hasAutoRoute`, which the filter already pins to 1 — a
  no-op ordering, so repeated polls of the same filter got back the exact same page, every run on
  it already parsed. Harmless while the filter was wide, fatal once bands narrow the result set to
  ~68 runs/dungeon/day. Now sorted by `completedAt desc`, so each poll leads with what appeared
  since the last one.

## Notes for review

- `COMBAT_LOG_POLLING_MYTHIC_LEVEL_MIN` is **no longer read** — deliberately a new config key
  rather than a reused one, because a stale `=10` in the production env would have silently killed
  the low bands. Worth removing from the production env. It is not in `.env.example`, and the new
  `COMBAT_LOG_POLLING_BAND_*` / `_TOP_BAND_*` vars all have working defaults.
- The migration is additive (two columns, unique index widened by one column) and backward
  compatible: old code writes `mythic_level_min = 0` and stays unique exactly as before. Existing
  rows get `mythic_level_max` backfilled to 0, because a null there marks the always-parsed top
  band.
- `CombatLogPollingBandService` logs its one operational warning through the `Log` facade rather
  than a `{Service}Logging` companion — the sibling `CombatLogParsingCriteriaService` has none
  either, but flagging it in case a companion is preferred.
- `getModelsEligibleForPolling()`'s top-band branch is defensive: `pollTopBand()` issues one
  all-dungeons query and never calls it today.

## Verification

- `--group=CombatLog` (318) and `--group=RaiderIO` (13) green; `composer run fix` and
  `composer run analyse` clean.
- Migration applied, rolled back and re-applied against the worktree DB.
- Band service smoke-tested against the live Raider.IO API (see numbers above).