### PR TITLE
#4024 Drop next-season nav link, hide Routes by Expansion on map pages

### DIFF
--- a/app/Http/View/Composers/HeaderComposer.php
+++ b/app/Http/View/Composers/HeaderComposer.php
@@ -38,7 +38,6 @@ readonly class HeaderComposer implements ViewComposerInterface
 
         $view->with('activeExpansions', $this->viewService->getActiveExpansions());
         $view->with('currentSeason', $currentSeason);
-        $view->with('nextSeason', $nextSeason);
         $view->with('allGameVersions', $this->viewService->getAllGameVersions());
 
         $userOrDefaultGameVersion = GameVersion::getUserOrDefaultGameVersion();

--- a/resources/views/common/layout/header.blade.php
+++ b/resources/views/common/layout/header.blade.php
@@ -17,13 +17,13 @@ use Illuminate\Support\Str;
  * @var Collection<int, Expansion>   $activeExpansions
  * @var Collection<int, Dungeon>     $gameVersionDungeons
  * @var Season                       $currentSeason
- * @var Season|null                  $nextSeason
  * @var Season|null                  $dungeonContextNextSeason
  * @var string|null                  $dungeonContextNextSeasonLink
  * @var bool                         $forceShrink
  * @var bool                         $showMore
  * @var bool                         $showDungeonContext
  * @var bool                         $showGameVersionSelection
+ * @var bool                         $showExpansionNav
  * @var Collection<string, string>   $dungeonContextLinks
  * @var string|false                 $headerId
  */
@@ -33,6 +33,7 @@ $showMore                 ??= false;
 $showDungeonContext       ??= true;
 // Map pages hide the game version selection row - it made the floating header too bulky
 $showGameVersionSelection ??= true;
+$showExpansionNav         ??= true;
 $forceShrink              ??= false;
 $dungeonContextLinks      ??= null;
 // The map view passes false (not null - ??= would overwrite null) - its own #map_header wraps
@@ -43,35 +44,10 @@ $headerId                 ??= 'site_header';
 // so an HTML error view rendered for one of those paths would otherwise crash here.
 $currentUserGameVersion   ??= GameVersion::getUserOrDefaultGameVersion();
 
-if ($currentUserGameVersion->key === GameVersion::GAME_VERSION_RETAIL) {
-    if ($nextSeason !== null) {
-        if ($nextSeason->expansion_id !== $currentSeason->expansion_id) {
-            $navs[route('dungeonroutes.expansion.season', [
-                'expansion' => $nextSeason->expansion,
-                'season'    => $nextSeason->index,
-            ])] = [
-                'text' => $nextSeason->name_long,
-            ];
-        } else {
-            $navs[route('dungeonroutes.season', [
-                'gameVersion' => $currentUserGameVersion,
-                'season'      => $nextSeason->index,
-            ])] = [
-                'text' => $nextSeason->name,
-            ];
-        }
-    }
-
-    $navs[route('dungeonroutes.gameVersion', ['gameVersion' => $currentUserGameVersion,])] = [
-        'fa'   => 'fa fa-route',
-        'text' => __('view_common.layout.header.browse_routes'),
-    ];
-} else {
-    $navs[route('dungeonroutes.gameVersion', ['gameVersion' => $currentUserGameVersion])] = [
-        'fa'   => 'fa fa-route',
-        'text' => __('view_common.layout.header.browse_routes'),
-    ];
-}
+$navs[route('dungeonroutes.gameVersion', ['gameVersion' => $currentUserGameVersion])] = [
+    'fa'   => 'fa fa-route',
+    'text' => __('view_common.layout.header.browse_routes'),
+];
 
 $expansionRoutes = [];
 foreach ($activeExpansions as $expansion) {
@@ -231,30 +207,32 @@ $isActiveRoute = function (string $route, bool $strict = false) {
                 @endif
             </ul>
             <ul class="navbar-nav">
-                <?php
-                /** @noinspection PhpUndefinedVariableInspection */
-                $hasSubItemActive = null;
-                $headerText       = __('view_common.layout.header.browse_by_expansion');
-                $dropdownId       = Str::slug($headerText);
-                // Determine if any of the sub-items are active
-                foreach ($expansionRoutes as $itemKey => $item) {
-                    $hasSubItemActive ??= $isActiveRoute($itemKey);
-                }
-                ?>
-                <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle {{ $hasSubItemActive }}" href="#" id="{{ $dropdownId }}"
-                       role="button"
-                       data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <i class="fas fa-stream"></i>
-                        {{ $headerText }}
-                    </a>
-                    <div class="dropdown-menu text-center text-xl-start" aria-labelledby="{{ $dropdownId }}">
-                        @foreach($expansionRoutes as $itemKey => $item)
-                            <a class="dropdown-item {{ $isActiveRoute($itemKey) }}"
-                               href="{{ $itemKey }}">{!! $item !!}</a>
-                        @endforeach
-                    </div>
-                </li>
+                @if($showExpansionNav)
+                    <?php
+                    /** @noinspection PhpUndefinedVariableInspection */
+                    $hasSubItemActive = null;
+                    $headerText       = __('view_common.layout.header.browse_by_expansion');
+                    $dropdownId       = Str::slug($headerText);
+                    // Determine if any of the sub-items are active
+                    foreach ($expansionRoutes as $itemKey => $item) {
+                        $hasSubItemActive ??= $isActiveRoute($itemKey);
+                    }
+                    ?>
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle {{ $hasSubItemActive }}" href="#" id="{{ $dropdownId }}"
+                           role="button"
+                           data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                            <i class="fas fa-stream"></i>
+                            {{ $headerText }}
+                        </a>
+                        <div class="dropdown-menu text-center text-xl-start" aria-labelledby="{{ $dropdownId }}">
+                            @foreach($expansionRoutes as $itemKey => $item)
+                                <a class="dropdown-item {{ $isActiveRoute($itemKey) }}"
+                                   href="{{ $itemKey }}">{!! $item !!}</a>
+                            @endforeach
+                        </div>
+                    </li>
+                @endif
                 @php($route = route('dungeon.explore.gameversion', ['gameVersion' => $currentUserGameVersion]))
                 <li class="nav-item">
                     <a class="nav-link pe-3 {{ $isActiveRoute($route) }}"

--- a/resources/views/common/layout/header.blade.php
+++ b/resources/views/common/layout/header.blade.php
@@ -16,7 +16,6 @@ use Illuminate\Support\Str;
  * @var Collection<int, GameVersion> $allGameVersions
  * @var Collection<int, Expansion>   $activeExpansions
  * @var Collection<int, Dungeon>     $gameVersionDungeons
- * @var Season                       $currentSeason
  * @var Season|null                  $dungeonContextNextSeason
  * @var string|null                  $dungeonContextNextSeasonLink
  * @var bool                         $forceShrink
@@ -50,13 +49,15 @@ $navs[route('dungeonroutes.gameVersion', ['gameVersion' => $currentUserGameVersi
 ];
 
 $expansionRoutes = [];
-foreach ($activeExpansions as $expansion) {
-    $expansionRoutes[route('dungeonroutes.expansion', ['expansion' => $expansion])] =
-        sprintf('<img src="%s" alt="%s" style="width: 50px"/> %s',
-            $expansion->getIconUrl(),
-            __($expansion->name),
-            __('view_common.layout.header.routes', ['expansion' => __($expansion->name)])
-        );
+if ($showExpansionNav) {
+    foreach ($activeExpansions as $expansion) {
+        $expansionRoutes[route('dungeonroutes.expansion', ['expansion' => $expansion])] =
+            sprintf('<img src="%s" alt="%s" style="width: 50px"/> %s',
+                $expansion->getIconUrl(),
+                __($expansion->name),
+                __('view_common.layout.header.routes', ['expansion' => __($expansion->name)])
+            );
+    }
 }
 
 if (Feature::active(Heatmap::class) && $currentUserGameVersion->key === GameVersion::GAME_VERSION_RETAIL) {

--- a/resources/views/common/maps/map.blade.php
+++ b/resources/views/common/maps/map.blade.php
@@ -268,6 +268,7 @@ if ($isAdmin) {
                 'showMore' => true,
                 'showDungeonContext' => !($mapContext instanceof MapContextDungeonRoute),
                 'showGameVersionSelection' => false,
+                'showExpansionNav' => false,
                 'forceShrink' => true,
                 'dungeonContextLinks' => $dungeonContextLinks,
             ])

--- a/tests/Feature/View/HeaderComposerTest.php
+++ b/tests/Feature/View/HeaderComposerTest.php
@@ -16,9 +16,9 @@ use Tests\TestCases\PublicTestCase;
 
 /**
  * The dungeon context bar follows the current season only. The upcoming season is advertised next to it
- * as a card of its own, and in the header nav link, but only once an admin has marked it `active` -
- * seasons are seeded weeks before they start so their mapping can be reviewed, and until then they should
- * not show up anywhere (#3761, #3868).
+ * as a card of its own, but only once an admin has marked it `active` - seasons are seeded weeks before
+ * they start so their mapping can be reviewed, and until then they should not show up anywhere
+ * (#3761, #3868).
  */
 #[Group('ViewComposers')]
 #[Group('HeaderComposer')]
@@ -44,7 +44,7 @@ final class HeaderComposerTest extends PublicTestCase
     }
 
     #[Test]
-    public function compose_givenAnActiveUpcomingSeason_setsTheNextSeasonAndCard(): void
+    public function compose_givenAnActiveUpcomingSeason_setsTheNextSeasonCard(): void
     {
         // Arrange - inside the try so a failure halfway through still cleans up
         $upcomingSeason = null;
@@ -60,7 +60,6 @@ final class HeaderComposerTest extends PublicTestCase
             // Assert
             $data = $view->getData();
 
-            $this->assertSame($upcomingSeason->id, $data['nextSeason']?->id);
             $this->assertNotNull($data['dungeonContextNextSeason']);
             $this->assertSame($upcomingSeason->id, $data['dungeonContextNextSeason']->id);
             $this->assertStringContainsString(sprintf('season=%d', $upcomingSeason->id), $data['dungeonContextNextSeasonLink']);
@@ -88,7 +87,6 @@ final class HeaderComposerTest extends PublicTestCase
             // Assert
             $data = $view->getData();
 
-            $this->assertNull($data['nextSeason'], 'An inactive season must not leak into the header nav link either');
             $this->assertNull($data['dungeonContextNextSeason']);
             $this->assertNull($data['dungeonContextNextSeasonLink']);
         } finally {
@@ -127,7 +125,6 @@ final class HeaderComposerTest extends PublicTestCase
             // Assert
             $data = $view->getData();
 
-            $this->assertSame($upcomingSeason->id, $data['nextSeason']?->id, 'The season should still be found, just not advertised as a card');
             $this->assertNull($data['dungeonContextNextSeason']);
             $this->assertNull($data['dungeonContextNextSeasonLink']);
         } finally {

--- a/tests/Feature/View/HeaderComposerTest.php
+++ b/tests/Feature/View/HeaderComposerTest.php
@@ -7,6 +7,8 @@ use App\Models\Expansion;
 use App\Models\GameVersion\GameVersion;
 use App\Models\Season;
 use App\Models\User;
+use App\Service\View\RequestViewContextInterface;
+use App\Service\View\ViewServiceInterface;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use PHPUnit\Framework\Attributes\Group;
@@ -127,6 +129,14 @@ final class HeaderComposerTest extends PublicTestCase
 
             $this->assertNull($data['dungeonContextNextSeason']);
             $this->assertNull($data['dungeonContextNextSeasonLink']);
+
+            // The season lookup itself must be unaffected by has_seasons - only the card is gated on it.
+            // Without this, the has_seasons gate could be broken (e.g. silently suppressing the season
+            // lookup itself) and the assertions above would pass vacuously.
+            $region      = app(RequestViewContextInterface::class)->getUserOrDefaultRegion();
+            $foundSeason = app(ViewServiceInterface::class)->getNextSeasonForRegion($region);
+            $this->assertNotNull($foundSeason, 'The season should still be found, just not advertised as a card');
+            $this->assertSame($upcomingSeason->id, $foundSeason->id);
         } finally {
             $user?->delete();
 
@@ -134,6 +144,30 @@ final class HeaderComposerTest extends PublicTestCase
                 $this->deleteSeason($upcomingSeason);
             }
         }
+    }
+
+    /**
+     * Map pages pass `showExpansionNav => false` to reclaim header space; every other page renders
+     * with the default (#4024).
+     */
+    #[Test]
+    public function render_givenShowExpansionNavDefault_rendersTheDropdown(): void
+    {
+        // Act
+        $html = view('common.layout.header')->render();
+
+        // Assert
+        $this->assertStringContainsString(__('view_common.layout.header.browse_by_expansion'), $html);
+    }
+
+    #[Test]
+    public function render_givenShowExpansionNavFalse_omitsTheDropdown(): void
+    {
+        // Act
+        $html = view('common.layout.header', ['showExpansionNav' => false])->render();
+
+        // Assert
+        $this->assertStringNotContainsString(__('view_common.layout.header.browse_by_expansion'), $html);
     }
 
     private function deleteSeason(Season $season): void

--- a/tests/Feature/View/ViewComposerTest.php
+++ b/tests/Feature/View/ViewComposerTest.php
@@ -93,7 +93,7 @@ final class ViewComposerTest extends PublicTestCase
     public function headerComposer_givenView_setsHeaderKeys(): void
     {
         $this->assertComposerSetsKeys(HeaderComposer::class, 'common.layout.header', [
-            'activeExpansions', 'currentSeason', 'nextSeason', 'allGameVersions', 'gameVersionDungeons',
+            'activeExpansions', 'currentSeason', 'allGameVersions', 'gameVersionDungeons',
             'dungeonContextNextSeason', 'dungeonContextNextSeasonLink',
         ]);
     }


### PR DESCRIPTION
:robot: Closes #4024

Testing the release on staging showed that with the NPC Compendium nav item enabled, the map-view header is too cramped. Two independent cleanups:

1. Removes the `$nextSeason` "Season N" nav link entirely (both map and non-map headers) - it's redundant with other views going forward.
2. Hides "Routes by Expansion" specifically on map pages to reclaim header space, while it still renders on non-map pages. A future issue will find an alternative way to expose this option on the map.

This is a pure Blade/PHP change and has already been hotfixed onto the deployed (not-yet-released-to-production) v15.11.0 staging build; this MR lands the same change permanently on `master`.