### PR TITLE
#4050 Count the combat log staleness window in days with data, not calendar days

### DIFF
--- a/app/Console/Commands/CombatLog/DetectStaleCombatLogDataCommand.php
+++ b/app/Console/Commands/CombatLog/DetectStaleCombatLogDataCommand.php
@@ -14,6 +14,7 @@ use App\Models\Npc\NpcCharacteristic;
 use App\Models\Spell\Spell;
 use App\Service\Season\SeasonServiceInterface;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use LogicException;
 
@@ -25,6 +26,14 @@ class DetectStaleCombatLogDataCommand extends Command
 
     /** @var Collection<int, int>|null */
     private ?Collection $currentSeasonDungeonIds = null;
+
+    /**
+     * Distinct `observed_on` dates (as 'Y-m-d' strings) present across both observation tables,
+     * sorted descending. Index 0 is the most recent data-day, index 1 the one before it, etc.
+     *
+     * @var Collection<int, string>|null
+     */
+    private ?Collection $dataDates = null;
 
     public function __construct(private readonly SeasonServiceInterface $seasonService)
     {
@@ -64,6 +73,49 @@ class DetectStaleCombatLogDataCommand extends Command
         return $this->currentSeasonDungeonIds = $currentSeason->seasonDungeons()->pluck('dungeon_id');
     }
 
+    /**
+     * @return Collection<int, string>
+     */
+    private function getDataDates(): Collection
+    {
+        if ($this->dataDates !== null) {
+            return $this->dataDates;
+        }
+
+        $npcDates = CombatLogNpcCharacteristicObservation::query()
+            ->distinct()
+            ->pluck('observed_on')
+            ->map(fn(Carbon $date) => $date->toDateString());
+
+        $spellDates = CombatLogSpellPropertyObservation::query()
+            ->distinct()
+            ->pluck('observed_on')
+            ->map(fn(Carbon $date) => $date->toDateString());
+
+        return $this->dataDates = $npcDates->merge($spellDates)
+            ->unique()
+            ->sortDesc()
+            ->values();
+    }
+
+    /**
+     * The date beyond which a fact with no fresher observation is considered stale, or null when
+     * there isn't yet enough observation history to say anything is stale.
+     */
+    private function getStalenessCutoff(): ?string
+    {
+        return $this->getDataDates()->get($this->observationWindowDays());
+    }
+
+    /**
+     * The date beyond which observation rows are pruned, or null when there isn't yet enough
+     * observation history to prune anything.
+     */
+    private function getPruneCutoff(): ?string
+    {
+        return $this->getDataDates()->get($this->observationWindowDays() + 1);
+    }
+
     private function removeStaleNpcCharacteristics(): void
     {
         $currentSeasonDungeonIds = $this->getCurrentSeasonDungeonIds();
@@ -73,8 +125,14 @@ class DetectStaleCombatLogDataCommand extends Command
             return;
         }
 
-        $cutoff = now()->subDays($this->observationWindowDays())->toDateString();
-        $total  = NpcCharacteristic::query()
+        $cutoff = $this->getStalenessCutoff();
+        if ($cutoff === null) {
+            $this->info('combatlog:detectstaledata — not enough observation history yet - skipping NPC characteristic stale detection.');
+
+            return;
+        }
+
+        $total = NpcCharacteristic::query()
             ->disableCache()
             ->whereIn('npc_id', function ($q) use ($currentSeasonDungeonIds): void {
                 $q->select('npc_id')->from('npc_dungeons')->whereIn('dungeon_id', $currentSeasonDungeonIds);
@@ -135,7 +193,13 @@ class DetectStaleCombatLogDataCommand extends Command
             return;
         }
 
-        $cutoff       = now()->subDays($this->observationWindowDays())->toDateString();
+        $cutoff = $this->getStalenessCutoff();
+        if ($cutoff === null) {
+            $this->info('combatlog:detectstaledata — not enough observation history yet - skipping spell property stale detection.');
+
+            return;
+        }
+
         $removedCount = 0;
 
         foreach (SpellProperty::cases() as $property) {
@@ -248,7 +312,12 @@ class DetectStaleCombatLogDataCommand extends Command
 
     private function pruneOldObservations(): void
     {
-        $pruneDate = now()->subDays($this->observationWindowDays() + 1)->toDateString();
+        $pruneDate = $this->getPruneCutoff();
+        if ($pruneDate === null) {
+            $this->info('combatlog:detectstaledata — not enough observation history yet - skipping observation pruning.');
+
+            return;
+        }
 
         $npcCount   = CombatLogNpcCharacteristicObservation::query()->where('observed_on', '<', $pruneDate)->delete();
         $spellCount = CombatLogSpellPropertyObservation::query()->where('observed_on', '<', $pruneDate)->delete();

--- a/tests/Feature/App/Console/Commands/CombatLog/DetectStaleCombatLogDataCommandTest.php
+++ b/tests/Feature/App/Console/Commands/CombatLog/DetectStaleCombatLogDataCommandTest.php
@@ -28,8 +28,35 @@ use Tests\TestCases\PublicTestCase;
 #[SlowTest]
 final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
 {
-    private const int NPC_ID   = 9995099;
-    private const int SPELL_ID = 9995098;
+    private const int NPC_ID        = 9995099;
+    private const int SPELL_ID      = 9995098;
+    private const int FILLER_NPC_ID = 9995096;
+
+    /** @var array<int, array<string, mixed>> */
+    private array $originalNpcObservations = [];
+
+    /** @var array<int, array<string, mixed>> */
+    private array $originalSpellObservations = [];
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // The staleness/prune cutoffs are now derived from the full, global contents of both
+        // observation tables, so a leftover row from seed data or a sibling test would silently
+        // shift which index a date lands on. Snapshot and empty both tables for the duration of
+        // the test; tearDown() restores them.
+        $this->originalNpcObservations = CombatLogNpcCharacteristicObservation::query()->get()
+            ->map(fn(CombatLogNpcCharacteristicObservation $observation) => $observation->getAttributes())
+            ->all();
+        $this->originalSpellObservations = CombatLogSpellPropertyObservation::query()->get()
+            ->map(fn(CombatLogSpellPropertyObservation $observation) => $observation->getAttributes())
+            ->all();
+
+        CombatLogNpcCharacteristicObservation::query()->toBase()->delete();
+        CombatLogSpellPropertyObservation::query()->toBase()->delete();
+    }
 
     #[\Override]
     protected function tearDown(): void
@@ -39,11 +66,19 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
             SpellDungeon::where('spell_id', self::SPELL_ID)->delete();
             NpcCharacteristic::where('npc_id', self::NPC_ID)->delete();
             Npc::where('id', self::NPC_ID)->delete();
-            CombatLogNpcCharacteristicObservation::where('npc_id', self::NPC_ID)->delete();
             CombatLogNpcEvent::where('npc_id', self::NPC_ID)->delete();
-            CombatLogSpellPropertyObservation::where('spell_id', self::SPELL_ID)->delete();
             CombatLogSpellEvent::where('spell_id', self::SPELL_ID)->delete();
             Spell::where('id', self::SPELL_ID)->delete();
+
+            CombatLogNpcCharacteristicObservation::query()->toBase()->delete();
+            CombatLogSpellPropertyObservation::query()->toBase()->delete();
+
+            if (!empty($this->originalNpcObservations)) {
+                CombatLogNpcCharacteristicObservation::query()->toBase()->insert($this->originalNpcObservations);
+            }
+            if (!empty($this->originalSpellObservations)) {
+                CombatLogSpellPropertyObservation::query()->toBase()->insert($this->originalSpellObservations);
+            }
         } finally {
             parent::tearDown();
         }
@@ -108,6 +143,25 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
         ]);
     }
 
+    /**
+     * Seeds $count distinct data-days (unrelated to the NPC/spell under test) so the command has
+     * enough observation history to derive a staleness/prune cutoff from. Days run from
+     * $startDaysAgo back to $startDaysAgo + $count - 1, relative to $mostRecent (defaults to now).
+     */
+    private function seedObservationDays(int $count, int $startDaysAgo = 0, ?Carbon $mostRecent = null): void
+    {
+        $mostRecent ??= now();
+
+        for ($i = 0; $i < $count; $i++) {
+            CombatLogNpcCharacteristicObservation::create([
+                'npc_id'            => self::FILLER_NPC_ID,
+                'characteristic_id' => Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH],
+                'observed_on'       => $mostRecent->copy()->subDays($startDaysAgo + $i)->toDateString(),
+                'combat_log_path'   => '/tmp/filler.log',
+            ]);
+        }
+    }
+
     private function getCurrentSeasonDungeonId(): int
     {
         return app(SeasonServiceInterface::class)
@@ -136,14 +190,17 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenStaleNpcCharacteristic_removesNpcCharacteristicAndCreatesRemovedEvent(): void
     {
         // Arrange
+        $windowDays       = config('keystoneguru.combat_log_staleness.observation_window_days');
         $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
+        $this->seedObservationDays($windowDays + 1);
         $this->createTestNpc();
         $this->linkNpcToCurrentSeason();
         NpcCharacteristic::create([
             'npc_id'            => self::NPC_ID,
             'characteristic_id' => $characteristicId,
         ]);
-        $this->createNpcCharacteristicObservation(now()->subDays(config('keystoneguru.combat_log_staleness.observation_window_days') + 1));
+        // Outside the populated window entirely — genuinely stale, not merely recent-but-old.
+        $this->createNpcCharacteristicObservation(now()->subDays($windowDays + 10));
 
         // Act
         $this->artisan(DetectStaleCombatLogDataCommand::class)->assertSuccessful();
@@ -165,6 +222,7 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenFreshNpcCharacteristic_doesNothing(): void
     {
         // Arrange
+        $windowDays       = config('keystoneguru.combat_log_staleness.observation_window_days');
         $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
         $this->createTestNpc();
         $this->linkNpcToCurrentSeason();
@@ -172,6 +230,8 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
             'npc_id'            => self::NPC_ID,
             'characteristic_id' => $characteristicId,
         ]);
+        // A populated window whose most recent data-day is the fact's own observation.
+        $this->seedObservationDays($windowDays, 1);
         $this->createNpcCharacteristicObservation(now());
 
         // Act
@@ -192,14 +252,16 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenStaleNpcCharacteristicNotInCurrentSeason_keepsNpcCharacteristic(): void
     {
         // Arrange
+        $windowDays       = config('keystoneguru.combat_log_staleness.observation_window_days');
         $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
+        $this->seedObservationDays($windowDays + 1);
         $this->createTestNpc();
         // Deliberately do NOT link NPC to any current-season dungeon
         NpcCharacteristic::create([
             'npc_id'            => self::NPC_ID,
             'characteristic_id' => $characteristicId,
         ]);
-        $this->createNpcCharacteristicObservation(now()->subDays(config('keystoneguru.combat_log_staleness.observation_window_days') + 1));
+        $this->createNpcCharacteristicObservation(now()->subDays($windowDays + 10));
 
         // Act
         $this->artisan(DetectStaleCombatLogDataCommand::class)->assertSuccessful();
@@ -219,11 +281,13 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenStaleSpellProperty_clearsPropertyAndCreatesRemovedEvent(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays + 1);
         $this->createTestSpell(['aura' => true]);
         $this->linkSpellToCurrentSeason();
         $this->createSpellPropertyObservation(
             SpellProperty::Aura,
-            now()->subDays(config('keystoneguru.combat_log_staleness.observation_window_days') + 1),
+            now()->subDays($windowDays + 10),
         );
 
         // Act
@@ -242,8 +306,10 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenFreshSpellProperty_doesNothing(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
         $this->createTestSpell(['aura' => true]);
         $this->linkSpellToCurrentSeason();
+        $this->seedObservationDays($windowDays, 1);
         $this->createSpellPropertyObservation(SpellProperty::Aura, now());
 
         // Act
@@ -261,11 +327,13 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenStaleSpellCounter_clearsCounterBitAndCreatesRemovedEvent(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays + 1);
         $this->createTestSpell(['counters_mask' => Spell::COUNTER_VANISH]);
         $this->linkSpellToCurrentSeason();
         $this->createSpellPropertyObservation(
             SpellProperty::CounterVanish,
-            now()->subDays(config('keystoneguru.combat_log_staleness.observation_window_days') + 1),
+            now()->subDays($windowDays + 10),
         );
 
         // Act
@@ -284,8 +352,10 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenFreshSpellCounter_doesNothing(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
         $this->createTestSpell(['counters_mask' => Spell::COUNTER_VANISH]);
         $this->linkSpellToCurrentSeason();
+        $this->seedObservationDays($windowDays, 1);
         $this->createSpellPropertyObservation(SpellProperty::CounterVanish, now());
 
         // Act
@@ -304,11 +374,13 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenStaleImmunityBypass_clearsImmunityBitAndCreatesRemovedEvent(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays + 1);
         $this->createTestSpell(['bypasses_immunities_mask' => Spell::IMMUNITY_DIVINE_SHIELD]);
         $this->linkSpellToCurrentSeason();
         $this->createSpellPropertyObservation(
             SpellProperty::BypassDivineShield,
-            now()->subDays(config('keystoneguru.combat_log_staleness.observation_window_days') + 1),
+            now()->subDays($windowDays + 10),
         );
 
         // Act
@@ -327,8 +399,10 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenFreshImmunityBypass_doesNothing(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
         $this->createTestSpell(['bypasses_immunities_mask' => Spell::IMMUNITY_DIVINE_SHIELD]);
         $this->linkSpellToCurrentSeason();
+        $this->seedObservationDays($windowDays, 1);
         $this->createSpellPropertyObservation(SpellProperty::BypassDivineShield, now());
 
         // Act
@@ -347,11 +421,13 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenStaleSpellPropertyNotInCurrentSeason_keepsSpellProperty(): void
     {
         // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays + 1);
         $this->createTestSpell(['aura' => true]);
         // Deliberately do NOT link Spell to any current-season dungeon
         $this->createSpellPropertyObservation(
             SpellProperty::Aura,
-            now()->subDays(config('keystoneguru.combat_log_staleness.observation_window_days') + 1),
+            now()->subDays($windowDays + 10),
         );
 
         // Act
@@ -372,13 +448,17 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
         config(['keystoneguru.combat_log_staleness.observation_window_days' => 3]);
         $this->app->instance(SeasonServiceInterface::class, new SeasonServiceStub());
 
+        // A continuous 5-day window (today .. 4 days ago) so the prune cutoff lands at 4 days ago.
+        $this->seedObservationDays(5);
+
         $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
         $this->createTestNpc();
         NpcCharacteristic::create([
             'npc_id'            => self::NPC_ID,
             'characteristic_id' => $characteristicId,
         ]);
-        // Stale observation (will be pruned) and a fresh one (will be kept)
+        // Stale observation (will be pruned, older than the 4-day prune cutoff) and a fresh one
+        // (will be kept, within the prune cutoff).
         $this->createNpcCharacteristicObservation(now()->subDays(5));
         $this->createNpcCharacteristicObservation(now()->subDays(3));
 
@@ -395,12 +475,147 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     }
 
     #[Test]
+    public function handle_givenNoObservationsToday_keepsDataAndCreatesNoRemovedEvents(): void
+    {
+        // Arrange
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $baseline   = now();
+
+        // A populated window ending "today" (the baseline), with the facts under test observed
+        // on that same baseline day.
+        $this->seedObservationDays($windowDays + 1, 0, $baseline);
+
+        $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
+        $this->createTestNpc();
+        $this->linkNpcToCurrentSeason();
+        NpcCharacteristic::create([
+            'npc_id'            => self::NPC_ID,
+            'characteristic_id' => $characteristicId,
+        ]);
+        $this->createNpcCharacteristicObservation($baseline);
+
+        $this->createTestSpell(['aura' => true]);
+        $this->linkSpellToCurrentSeason();
+        $this->createSpellPropertyObservation(SpellProperty::Aura, $baseline);
+
+        try {
+            // Simulate a drought: several days pass with no new ingest at all, so no new data-day
+            // ever enters the observation tables.
+            Carbon::setTestNow($baseline->copy()->addDays($windowDays + 3));
+
+            // Act
+            $this->artisan(DetectStaleCombatLogDataCommand::class)->assertSuccessful();
+
+            // Assert — the Compendium freezes: nothing decayed because the cutoff never moved.
+            $this->assertDatabaseHas('npc_characteristics', [
+                'npc_id'            => self::NPC_ID,
+                'characteristic_id' => $characteristicId,
+            ]);
+            $this->assertDatabaseMissing('combat_log_npc_events', [
+                'npc_id'     => self::NPC_ID,
+                'event_type' => CombatLogNpcEventType::CharacteristicRemoved->value,
+            ], 'combatlog');
+
+            $this->assertDatabaseHas('spells', ['id' => self::SPELL_ID, 'aura' => true]);
+            $this->assertDatabaseMissing('combat_log_spell_events', [
+                'spell_id'   => self::SPELL_ID,
+                'event_type' => CombatLogSpellEventType::PropertyRemoved->value,
+            ], 'combatlog');
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    #[Test]
+    public function handle_givenContinuousIngest_removesStaleDataAsBefore(): void
+    {
+        // Arrange — regression guard on the cutoff index: under continuous ingest, a fact last
+        // observed exactly window+1 data-days ago must still be removed.
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays + 2);
+
+        $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
+        $this->createTestNpc();
+        $this->linkNpcToCurrentSeason();
+        NpcCharacteristic::create([
+            'npc_id'            => self::NPC_ID,
+            'characteristic_id' => $characteristicId,
+        ]);
+        $this->createNpcCharacteristicObservation(now()->subDays($windowDays + 1));
+
+        // Act
+        $this->artisan(DetectStaleCombatLogDataCommand::class)->assertSuccessful();
+
+        // Assert
+        $this->assertDatabaseMissing('npc_characteristics', [
+            'npc_id'            => self::NPC_ID,
+            'characteristic_id' => $characteristicId,
+        ]);
+        $this->assertDatabaseHas('combat_log_npc_events', [
+            'npc_id'      => self::NPC_ID,
+            'event_type'  => CombatLogNpcEventType::CharacteristicRemoved->value,
+            'model_class' => Characteristic::class,
+            'model_id'    => $characteristicId,
+        ], 'combatlog');
+    }
+
+    #[Test]
+    public function handle_givenFewerObservationDaysThanWindow_removesNothing(): void
+    {
+        // Arrange — only window_days distinct data-days exist, one short of the window+1 needed
+        // to define a staleness cutoff at all.
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays);
+
+        $characteristicId = Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH];
+        $this->createTestNpc();
+        $this->linkNpcToCurrentSeason();
+        NpcCharacteristic::create([
+            'npc_id'            => self::NPC_ID,
+            'characteristic_id' => $characteristicId,
+        ]);
+
+        // Act
+        $this->artisan(DetectStaleCombatLogDataCommand::class)->assertSuccessful();
+
+        // Assert — not enough evidence to call anything stale
+        $this->assertDatabaseHas('npc_characteristics', [
+            'npc_id'            => self::NPC_ID,
+            'characteristic_id' => $characteristicId,
+        ]);
+        $this->assertDatabaseMissing('combat_log_npc_events', [
+            'npc_id'     => self::NPC_ID,
+            'event_type' => CombatLogNpcEventType::CharacteristicRemoved->value,
+        ], 'combatlog');
+    }
+
+    #[Test]
+    public function handle_givenFewerObservationDaysThanWindowPlusOne_prunesNothing(): void
+    {
+        // Arrange — window_days+1 distinct data-days exist, one short of the window_days+2 needed
+        // to define a prune cutoff at all.
+        $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
+        $this->seedObservationDays($windowDays + 1);
+
+        $countBefore = CombatLogNpcCharacteristicObservation::count();
+
+        // Act
+        $this->artisan(DetectStaleCombatLogDataCommand::class)->assertSuccessful();
+
+        // Assert — not enough evidence to prune anything, even the oldest of these rows
+        $this->assertSame($countBefore, CombatLogNpcCharacteristicObservation::count());
+    }
+
+    #[Test]
     public function handle_prunesObservationsOlderThanFourDays(): void
     {
-        // Arrange — pin the observation window to 3 so the prune threshold is predictable regardless of .env
+        // Arrange — pin the observation window to 3 so the derived cutoffs are predictable
         config(['keystoneguru.combat_log_staleness.observation_window_days' => 3]);
 
-        // create observations at different ages
+        // A continuous 5-day window (today .. 4 days ago) so the staleness cutoff lands at
+        // 3 days ago and the prune cutoff at 4 days ago.
+        $this->seedObservationDays(5);
+
         $this->createTestNpc();
         $this->linkNpcToCurrentSeason();
         NpcCharacteristic::create([
@@ -408,9 +623,9 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
             'characteristic_id' => Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH],
         ]);
 
-        // 3 days old → should be kept (within prune window)
+        // 3 days old → at the staleness cutoff, and within the prune window → kept
         $this->createNpcCharacteristicObservation(now()->subDays(3));
-        // 5 days old → should be pruned (outside prune window of 4 days)
+        // 5 days old → older than the prune cutoff (4 days ago) → pruned
         CombatLogNpcCharacteristicObservation::create([
             'npc_id'            => self::NPC_ID,
             'characteristic_id' => Characteristic::ALL[Characteristic::CHARACTERISTIC_POLYMORPH],
@@ -420,9 +635,9 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
 
         $this->createTestSpell(['aura' => true]);
         $this->linkSpellToCurrentSeason();
-        // 3 days old → should be kept
+        // 3 days old → kept
         $this->createSpellPropertyObservation(SpellProperty::Aura, now()->subDays(3));
-        // 5 days old → should be pruned
+        // 5 days old → pruned
         CombatLogSpellPropertyObservation::create([
             'spell_id'        => self::SPELL_ID,
             'property'        => SpellProperty::Aura,

--- a/tests/Feature/App/Console/Commands/CombatLog/DetectStaleCombatLogDataCommandTest.php
+++ b/tests/Feature/App/Console/Commands/CombatLog/DetectStaleCombatLogDataCommandTest.php
@@ -5,9 +5,7 @@ namespace Tests\Feature\App\Console\Commands\CombatLog;
 use App\Console\Commands\CombatLog\DetectStaleCombatLogDataCommand;
 use App\Models\Characteristic;
 use App\Models\CombatLog\CombatLogNpcCharacteristicObservation;
-use App\Models\CombatLog\CombatLogNpcEvent;
 use App\Models\CombatLog\CombatLogNpcEventType;
-use App\Models\CombatLog\CombatLogSpellEvent;
 use App\Models\CombatLog\CombatLogSpellEventType;
 use App\Models\CombatLog\CombatLogSpellPropertyObservation;
 use App\Models\CombatLog\SpellProperty;
@@ -19,6 +17,7 @@ use App\Models\Spell\SpellDungeon;
 use App\Service\Season\SeasonServiceInterface;
 use App\Service\Season\SeasonServiceStub;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\Attributes\SlowTest;
@@ -32,27 +31,24 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     private const int SPELL_ID      = 9995098;
     private const int FILLER_NPC_ID = 9995096;
 
-    /** @var array<int, array<string, mixed>> */
-    private array $originalNpcObservations = [];
-
-    /** @var array<int, array<string, mixed>> */
-    private array $originalSpellObservations = [];
-
     #[\Override]
     protected function setUp(): void
     {
         parent::setUp();
 
         // The staleness/prune cutoffs are now derived from the full, global contents of both
-        // observation tables, so a leftover row from seed data or a sibling test would silently
-        // shift which index a date lands on. Snapshot and empty both tables for the duration of
-        // the test; tearDown() restores them.
-        $this->originalNpcObservations = CombatLogNpcCharacteristicObservation::query()->get()
-            ->map(fn(CombatLogNpcCharacteristicObservation $observation) => $observation->getAttributes())
-            ->all();
-        $this->originalSpellObservations = CombatLogSpellPropertyObservation::query()->get()
-            ->map(fn(CombatLogSpellPropertyObservation $observation) => $observation->getAttributes())
-            ->all();
+        // observation tables, so a leftover row from real data or a sibling test would silently
+        // shift which index a date lands on. Wrap both connections in a transaction for the
+        // duration of the test and roll back in tearDown() — this both empties the observation
+        // tables for a clean, controlled slate AND undoes any real npc_characteristics/spells
+        // rows the command mutates while scanning every current-season fact against that empty
+        // slate (those rows are combat-log-derived and not recoverable, so a plain
+        // truncate-and-restore of only the observation tables is not safe here).
+        // The default connection is 'phpunit' in the test environment (config/database.php), not
+        // 'mysql' — use the unqualified DB facade so this targets whichever connection the models
+        // actually resolve to.
+        DB::beginTransaction();
+        DB::connection('combatlog')->beginTransaction();
 
         CombatLogNpcCharacteristicObservation::query()->toBase()->delete();
         CombatLogSpellPropertyObservation::query()->toBase()->delete();
@@ -62,23 +58,8 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     protected function tearDown(): void
     {
         try {
-            NpcDungeon::where('npc_id', self::NPC_ID)->delete();
-            SpellDungeon::where('spell_id', self::SPELL_ID)->delete();
-            NpcCharacteristic::where('npc_id', self::NPC_ID)->delete();
-            Npc::where('id', self::NPC_ID)->delete();
-            CombatLogNpcEvent::where('npc_id', self::NPC_ID)->delete();
-            CombatLogSpellEvent::where('spell_id', self::SPELL_ID)->delete();
-            Spell::where('id', self::SPELL_ID)->delete();
-
-            CombatLogNpcCharacteristicObservation::query()->toBase()->delete();
-            CombatLogSpellPropertyObservation::query()->toBase()->delete();
-
-            if (!empty($this->originalNpcObservations)) {
-                CombatLogNpcCharacteristicObservation::query()->toBase()->insert($this->originalNpcObservations);
-            }
-            if (!empty($this->originalSpellObservations)) {
-                CombatLogSpellPropertyObservation::query()->toBase()->insert($this->originalSpellObservations);
-            }
+            DB::rollBack();
+            DB::connection('combatlog')->rollBack();
         } finally {
             parent::tearDown();
         }
@@ -593,9 +574,11 @@ final class DetectStaleCombatLogDataCommandTest extends PublicTestCase
     public function handle_givenFewerObservationDaysThanWindowPlusOne_prunesNothing(): void
     {
         // Arrange — window_days+1 distinct data-days exist, one short of the window_days+2 needed
-        // to define a prune cutoff at all.
+        // to define a prune cutoff at all. Offset them well into the past (not ending "today") so
+        // the old calendar-based cutoff would have pruned every one of them — otherwise this test
+        // would pass vacuously even with the null-guard removed.
         $windowDays = config('keystoneguru.combat_log_staleness.observation_window_days');
-        $this->seedObservationDays($windowDays + 1);
+        $this->seedObservationDays($windowDays + 1, 10);
 
         $countBefore = CombatLogNpcCharacteristicObservation::count();
 


### PR DESCRIPTION
:robot: Closes #4050

Structural follow-up to #4035 / #4036, which hotfixed the symptom by widening `combatlog:pollruns`' poll window. `combatlog:detectstaledata` staleness/prune cutoffs were computed from `now()->subDays(N)`, a calendar cutoff that keeps moving even on days with zero ingest — so a multi-day gap between seasons (or any content drought) would mass-remove current-season NPC characteristics and spell properties that were never actually stale, just unobserved during the gap. The data is combat-log-derived and not recoverable from the seeders.

## Fix

Both the staleness cutoff and the prune cutoff are now derived from the distinct `observed_on` dates actually present across `combat_log_npc_characteristic_observations` and `combat_log_spell_property_observations` (unioned, sorted descending, memoized per command run), instead of `now()`. With `$dates` 0-indexed descending: staleness cutoff = `$dates[N]`, prune cutoff = `$dates[N + 1]`, where `N` is `observation_window_days` (default 3). If fewer than `N + 1` (or `N + 2`) distinct dates exist, the corresponding cutoff is `null` and that phase is skipped entirely — not enough evidence to call anything stale.

Effect: a dry ingest day no longer moves the cutoff at all, so the Compendium freezes at yesterday's state instead of aging toward a wipe. Continuous ingest keeps behaving exactly as before (the window advances one data-day per data-day).

## Tests

Rewrote `DetectStaleCombatLogDataCommandTest` — the cutoff is now derived from the *global* contents of both observation tables, so each test truncates and restores both tables around itself in `setUp`/`tearDown` for isolation, and a `seedObservationDays()` helper seeds a controlled run of distinct data-days for a fact to be tested against. Added cases for the freeze behaviour (`givenNoObservationsToday`), the continuous-ingest regression guard on the index choice, and the "not enough history yet" edge cases for both the staleness and prune cutoffs.

## Verification

- `docker compose exec -T app php artisan test --compact --filter=DetectStaleCombatLogDataCommand` — 16 passed.
- `composer run analyse` — no errors.
- `composer run fix` — only the two intended files touched.
