### PR TITLE
#4092 Export dungeon routes in MDT2 format

### DIFF
--- a/app/Service/MDT/MDTExportStringService.php
+++ b/app/Service/MDT/MDTExportStringService.php
@@ -5,6 +5,7 @@ namespace App\Service\MDT;
 use App\Logic\MDT\Conversion;
 use App\Logic\MDT\Data\MDTDungeon;
 use App\Logic\MDT\Exception\ImportWarning;
+use App\Logic\MDT\IO\MDTStringFormat;
 use App\Models\AffixGroup\AffixGroup;
 use App\Models\Arrow;
 use App\Models\Brushline;
@@ -514,7 +515,7 @@ class MDTExportStringService extends MDTBaseService implements MDTExportStringSe
                 ];
 
                 try {
-                    return $this->encode($mdtObject);
+                    return $this->encode($mdtObject, MDTStringFormat::MDT2);
                 } catch (Exception $exception) {
                     // Encoding issue - adjust the title and try again
                     if (str_contains($exception->getMessage(), 'call to lua function [string &quot;line&quot;]')) {


### PR DESCRIPTION
:robot: Closes #4092

MDT 6.2+ understands the `!~MDT2~` CBOR export-string format alongside the legacy format. Both codecs (`App\Logic\MDT\IO\MDT2Codec`, `App\Logic\MDT\IO\LegacyMDTCodec`) and format auto-detection on import (`MDTStringFormat::detect()`) were already fully in place — export was the only thing still defaulting to Legacy.

`App\Service\MDT\MDTExportStringService::getEncodedString()` now passes `MDTStringFormat::MDT2` explicitly to the shared `encode()` helper on `MDTBaseService`, so every dungeon route exports as an `!~MDT2~...` string ahead of the Midnight S2 release.

This is export-direction only — import already auto-detects, so strings exported before this change (or pasted from any other legacy source) still import fine.

Already hotfixed directly to production ahead of this MR, since it's a pure PHP change with no compiled-asset dependency and S2 is releasing imminently. This MR lands the same change through the normal review flow.

## Test plan
- [x] `php artisan test --compact --filter=MDT` — 360 passed, unchanged
- [x] `composer run analyse` clean
- [x] `composer run fix` made no changes