### PR TITLE
#4123 Added new combat log version 12.1.0

### DIFF
--- a/app/Logic/CombatLog/CombatLogVersion.php
+++ b/app/Logic/CombatLog/CombatLogVersion.php
@@ -19,6 +19,7 @@ class CombatLogVersion
     public const int RETAIL_12_0_1      = 22_012_000_001;
     public const int RETAIL_12_0_5      = 22_012_000_005;
     public const int RETAIL_12_0_7      = 22_012_000_007;
+    public const int RETAIL_12_1_0      = 22_012_001_000;
 
     public const array RETAIL_ALL = [
         self::RETAIL_10_1_0 => 2,
@@ -31,6 +32,7 @@ class CombatLogVersion
         self::RETAIL_12_0_1 => 12,
         self::RETAIL_12_0_5 => 14,
         self::RETAIL_12_0_7 => 15,
+        self::RETAIL_12_1_0 => 16,
     ];
 
     public const array ALL = [
@@ -49,5 +51,6 @@ class CombatLogVersion
         self::CLASSIC_TBC_2_5_5  => 13,
         self::RETAIL_12_0_5      => 14,
         self::RETAIL_12_0_7      => 15,
+        self::RETAIL_12_1_0      => 16,
     ];
 }

--- a/tests/Unit/App/Logic/CombatLog/SpecialEvents/CombatLogVersion/CombatLogVersionTest.php
+++ b/tests/Unit/App/Logic/CombatLog/SpecialEvents/CombatLogVersion/CombatLogVersionTest.php
@@ -52,6 +52,10 @@ final class CombatLogVersionTest extends PublicTestCase
                 '7/19/2026 19:31:59.774-6  COMBAT_LOG_VERSION,22,ADVANCED_LOG_ENABLED,1,BUILD_VERSION,12.0.7,PROJECT_ID,1',
                 CombatLogVersion::RETAIL_12_0_7,
             ],
+            'retail-12-1-0' => [
+                '7/19/2026 19:31:59.774-6  COMBAT_LOG_VERSION,22,ADVANCED_LOG_ENABLED,1,BUILD_VERSION,12.1.0,PROJECT_ID,1',
+                CombatLogVersion::RETAIL_12_1_0,
+            ],
         ];
     }
 }

--- a/tests/Unit/App/Logic/CombatLog/SpecialEvents/RioLogVersion/RioLogVersionTest.php
+++ b/tests/Unit/App/Logic/CombatLog/SpecialEvents/RioLogVersion/RioLogVersionTest.php
@@ -192,7 +192,7 @@ final class RioLogVersionTest extends PublicTestCase
             'mplus-trash-win32-missing-version-quad' => [
                 // Same-version addon builds (observed on APP_VERSION 4.11.2) sometimes drop the
                 // entire trailing COMBAT_LOG_VERSION/ADVANCED_LOG_ENABLED/BUILD_VERSION/PROJECT_ID
-                // quad. Expected values here are RETAIL_ALL's current newest entry (22/12.0.7) —
+                // quad. Expected values here are RETAIL_ALL's current newest entry (22/12.1.0) —
                 // the fallback used when the quad is missing — update if a newer version is
                 // registered.
                 '7/19/2026 22:55:47.9768  RIO_LOG_VERSION,1,SEGMENT_TYPE,mplus_trash,APP_VERSION,4.11.2,PROCESSOR_VERSION,1,PLATFORM,win32,INSTANCE_ID,658,DUNGEON_ID,556,SEGMENT_ID,1,CORRELATION_ID,658-10-162-10-9-6fb3ec76b0ae89845ff190da15305ce6859fd382bdcc195dd164080a2cc30512,CHALLENGE_MODE_STARTED_AT,1784472947055,TYPE,trash,CLIENT_SESSION_ID,db371d19-50f4-4b1b-9316-ad6302db1f65',
@@ -212,7 +212,7 @@ final class RioLogVersionTest extends PublicTestCase
                 'db371d19-50f4-4b1b-9316-ad6302db1f65',
                 22,
                 true,
-                '12.0.7',
+                '12.1.0',
                 1,
             ],
             'mplus-boss-win32-missing-version-quad' => [
@@ -236,7 +236,7 @@ final class RioLogVersionTest extends PublicTestCase
                 'db371d19-50f4-4b1b-9316-ad6302db1f65',
                 22,
                 true,
-                '12.0.7',
+                '12.1.0',
                 1,
             ],
         ];


### PR DESCRIPTION
Closes #4123

Registers combat log version 12.1.0 (22_012_001_000). All version-gated `match` builders already fall through to their newest handler via a `default =>` arm (verified in cold review), so this is registry-only, same low-risk shape as the 12.0.7 precedent (#3632).

Note: unlike #3632, there is no real failing run to replay end-to-end against yet — checked Sentry for `combatLogVersion:22012001000` / "Unable to find combat log version" / `UnhandledMatchError` over 90 days, zero hits, both resolved and unresolved. The real-data re-parse verification that precedent did should happen once actual 12.1.0 logs start producing failures.