### PR TITLE
#4146 Fix floor cache lagging one event behind on floor change

### DIFF
--- a/app/Service/CombatLog/Builders/CombatLogRouteDungeonRouteBuilder.php
+++ b/app/Service/CombatLog/Builders/CombatLogRouteDungeonRouteBuilder.php
@@ -173,10 +173,9 @@ class CombatLogRouteDungeonRouteBuilder extends DungeonRouteBuilder
                 $newFloor = $floorCache->get($event['npc']->coord->uiMapId);
 
                 if ($newFloor === null) {
-                    $floorCache->put(
-                        $event['npc']->coord->uiMapId,
-                        $this->floorRepository->findByUiMapId($event['npc']->coord->uiMapId, $this->dungeonRoute->dungeon_id),
-                    );
+                    $newFloor = $this->floorRepository->findByUiMapId($event['npc']->coord->uiMapId, $this->dungeonRoute->dungeon_id);
+
+                    $floorCache->put($event['npc']->coord->uiMapId, $newFloor);
                 }
 
                 if ($newFloor === null) {


### PR DESCRIPTION
:robot: Closes #4146

`buildKillZones()` read `$newFloor` from `$floorCache` before the repository lookup result was ever put into the cache, so the first event on a new `uiMapId` always hit a null cache lookup. It only self-corrected on the *next* event for the same floor (because by then the cache had been populated), meaning `currentFloor` lagged one event behind on every floor change.

`currentFloor` feeds `enemy_engagement_max_range` / `enemy_engagement_max_range_patrols` lookups, so the first kill after a floor transition could be matched using the previous floor's engagement ranges on dungeons where floors override those values. It also caused `buildKillZonesNewCurrentFloor` to under-report floor changes in structured logs.

Fix: assign the repository lookup result to `$newFloor` and cache that value, instead of caching without reading it back.

Cold review skipped under the trivial-change rule (3 changed lines, no UI/schema/auth/security impact, covered by the existing `CombatLogRoute` test suite).

## Test plan
- [x] `docker compose exec -T app php artisan test --compact --filter=CombatLogRoute` — 71 passed, no pinned pull-count regressions
- [x] `composer run fix` / `composer run analyse` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7ZNExCW4A9FkGuFr74XEr
