### PR TITLE
#4331 Make the facade-location diagnostic actionable

### DIFF
--- a/app/Http/Controllers/Ajax/AjaxKillZoneController.php
+++ b/app/Http/Controllers/Ajax/AjaxKillZoneController.php
@@ -170,10 +170,13 @@ class AjaxKillZoneController extends Controller
             // watching their marker silently disappear. 422 as a literal, like
             // abortIfDungeonRouteLimitReached() - Teapot's Http does not expose UNPROCESSABLE_ENTITY
             //
-            // Floor union areas are expected to tile the entire facade map with no gaps, so this
-            // should never trigger - reported to diagnose which mapping version/floor unions do.
+            // Expected to be rare (see the dead-space note above), not impossible - reported with the
+            // submitted lat/lng so an occurrence can actually be plotted against the mapping version's
+            // floor unions instead of only naming which one was hit.
             report(new Exception(sprintf(
-                'Facade location could not be converted to a real floor for mapping version %d, submitted floor %d',
+                'Facade location (%s, %s) could not be converted to a real floor for mapping version %d, submitted floor %d',
+                $data['lat'],
+                $data['lng'],
                 $dungeonRoute->mappingVersion->id,
                 $submittedFloor->id,
             )));


### PR DESCRIPTION
## Summary
Closes #4331.

The Sentry report fired once for mapping version 904 / submitted floor 464, with a code comment claiming this "should never trigger" since floor union areas are expected to tile the facade map with no gaps.

I verified that claim directly: an exhaustive scan of mapping version 904's floor unions against floor 464 (probing the whole facade map at 0.25-unit resolution, ~1.57M points) found **zero coverage gaps** — every point converts to a real floor. So this isn't a mapping-data defect in 904. The "should never trigger" comment also directly contradicts the dead-space note two lines above it in the same function (`app/Http/Controllers/Ajax/AjaxKillZoneController.php:153-154`), which already documents that ~0.003% dead space is expected across facade dungeons.

Separately, the report as originally written carried no submitted lat/lng, so the issue's own ask ("inspect mapping version 904's floor unions against floor 464 ... at the submitted location") was unanswerable from the report alone.

Fix:
- Corrected the comment so it agrees with the dead-space note instead of contradicting it.
- Added the submitted lat/lng to the `report()` call so a future occurrence can actually be plotted against the relevant floor unions.
- Left the `abort(422)` behavior untouched — refusing an unconvertible new location (rather than persisting a facade floor or silently dropping it) is still correct.

## Test plan
- [x] `docker compose exec -T app php artisan test --compact --filter=AjaxKillZoneControllerTest` — 17 passed, no regressions (existing test coverage for this branch, from #3917, doesn't assert on report content so needed no changes)
- [x] `composer run analyse` on the changed file — no errors
- [x] `composer run fix --dry-run --diff` on the changed file — clean