### PR TITLE
#4371 Fix Patreon benefits dropdown showing raw translation keys

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -26,8 +26,12 @@ class UserController extends Controller
     public function get(): View
     {
         return view('admin.user.list', [
-            'allPatreonBenefits' => PatreonBenefit::all(),
-            'allRoles'           => Role::all(),
+            'allPatreonBenefits' => PatreonBenefit::all()->map(fn(PatreonBenefit $benefit) => [
+                'id'   => $benefit->id,
+                'key'  => $benefit->key,
+                'name' => __($benefit->name),
+            ]),
+            'allRoles' => Role::all(),
         ]);
     }
 

--- a/resources/views/admin/user/list.blade.php
+++ b/resources/views/admin/user/list.blade.php
@@ -135,10 +135,6 @@ use Illuminate\Support\Collection;
                                 let template = Handlebars.templates['admin_users_table_row_patreon'];
 
                                 let patreonBenefitsCopy = JSON.parse(JSON.stringify(patreonBenefits));
-                                for (let j = 0; j < patreonBenefitsCopy.length; j++) {
-                                    // Translate the patreon benefit's name
-                                    patreonBenefitsCopy[j].name = lang.get(patreonBenefitsCopy[j].name);
-                                }
 
                                 for (let i = 0; i < row.patreon_user_link.patreonbenefits.length; i++) {
                                     let userPaidTier = row.patreon_user_link.patreonbenefits[i];

--- a/resources/views/admin/user/list.blade.php
+++ b/resources/views/admin/user/list.blade.php
@@ -135,12 +135,14 @@ use Illuminate\Support\Collection;
                                 let template = Handlebars.templates['admin_users_table_row_patreon'];
 
                                 let patreonBenefitsCopy = JSON.parse(JSON.stringify(patreonBenefits));
+                                for (let j = 0; j < patreonBenefitsCopy.length; j++) {
+                                    // Translate the patreon benefit's name
+                                    patreonBenefitsCopy[j].name = lang.get(patreonBenefitsCopy[j].name);
+                                }
+
                                 for (let i = 0; i < row.patreon_user_link.patreonbenefits.length; i++) {
                                     let userPaidTier = row.patreon_user_link.patreonbenefits[i];
                                     for (let j = 0; j < patreonBenefitsCopy.length; j++) {
-                                        // Translate the patreon benefit's name
-                                        patreonBenefitsCopy[j].name = lang.get(patreonBenefitsCopy[j].name);
-
                                         if (patreonBenefitsCopy[j].id === userPaidTier.id) {
                                             patreonBenefitsCopy[j].selected = true;
                                         }


### PR DESCRIPTION
## Summary
- The admin users list's Patreon benefits multiselect only translated each benefit's `name` (e.g. `patreonbenefits.ad-free`) inside the loop over the user's *already-granted* benefits.
- A user with a Patreon link but zero granted benefits never entered that loop, so the dropdown options rendered the raw translation keys instead of the localized labels.
- Moved the translation step into its own loop over all available benefits, run unconditionally, before marking any as selected.

## Test plan
- No unit-test seam exists for this inline `@section('scripts')` JS in the blade file, so this was verified by code inspection: confirmed `patreonbenefits.*` is the same translation key format the profile page already uses successfully via `__($patreonBenefit->name)` (`resources/views/profile/edittabs/patreon.blade.php:61`), ruling out a broader translation-resolution problem — the bug was purely the loop placement.
- [ ] Manually verify in the admin panel: open the users list, find a user with a Patreon link and zero granted benefits, and confirm the benefits dropdown shows translated labels (e.g. "Ad-free") instead of raw keys.

Closes #4371