### PR TITLE
#4384 Exclude storage/debugbar and storage/logs noise from codebase-memory-mcp coverage reports

### DIFF
--- a/.cbmignore
+++ b/.cbmignore
@@ -7,6 +7,12 @@ storage/framework/
 # Container config and MySQL data directories - not source.
 docker-compose/
 
+# Gitignored runtime output (debug snapshots, request logs) — already excluded per-file via root
+# .gitignore/nested .gitignore, but listing them here collapses the coverage report's not_indexed
+# list from hundreds of individual file entries to two directory entries.
+storage/debugbar/
+storage/logs/
+
 # Re-include tracked source that CBM's built-in skip-list drops by directory name.
 !resources/assets/
 !database/migrations/


### PR DESCRIPTION
Closes #4384

## Summary
- `storage/debugbar/*.json` and `storage/logs/*.log` are already excluded from indexing (per-file, via gitignore), but `codebase-memory-mcp`'s `not_indexed` coverage report enumerated every individual excluded file instead of collapsing by directory — ~460 entries of pure noise in every `index_status`/`check_index_coverage` response.
- Adding both dirs to `.cbmignore` explicitly folds them into the directory-level exclusion list instead. Nothing about what gets indexed changes — this is purely a report-size fix.
- Measured via `codebase-memory-mcp cli index_status`: `not_indexed.files_count` 482 → 26, raw response 46,907 → 10,500 bytes (78% smaller).

## Test plan
- [x] Re-ran `index_repository` with the updated `.cbmignore` and confirmed `storage/debugbar` and `storage/logs` moved from the `files` list into the `dirs` list in `index_status`
- [x] Confirmed node/edge counts unchanged (67,536 nodes / 160,882 edges before and after — nothing new is being indexed, only the report shrank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RncXMuf8k5MLy3twBjSjsV