### PR TITLE
#4390 Disable php-cs-fixer parallel workers entirely

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -21,10 +21,10 @@ return (new PhpCsFixer\Config())
     ->setIndent("    ")
     ->setLineEnding("\n")
     ->setFinder($finder)
-    // Capped at 4: an interrupted `composer run fix` (Bash-tool timeout, Ctrl-C, session end)
-    // orphans its workers instead of killing them, and each spins at ~100% CPU forever. detect()
-    // alone would cap that at (core count - 1); this bounds the worst case regardless of host size.
-    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect(null, null, 4))
+    // No parallel config: an interrupted `composer run fix` (Bash-tool timeout, Ctrl-C, session
+    // end) orphans its workers instead of killing them, and each spins at ~100% CPU forever.
+    // Capping the worker count (#4381/#4382) only lowered the ceiling and the leak still
+    // recurred (#4390), so parallelism is disabled entirely - single-process, no orphans possible.
     ->setRules([
         // Arrays & commas
         'array_syntax'                => ['syntax' => 'short'],


### PR DESCRIPTION
## Summary
- The #4381/#4382 worker cap (`ParallelConfigFactory::detect(null, null, 4)`) only lowered the ceiling on orphaned php-cs-fixer workers pegging CPU after an interrupted `composer run fix` — the leak recurred across three worktrees despite the cap.
- Removes `->setParallelConfig(...)` from `.php-cs-fixer.php` entirely so fixer runs single-process; with no parallel runner there are no worker processes left to orphan.

Closes #4390

## Test plan
- [x] `php -l .php-cs-fixer.php` — no syntax errors
- [x] Reviewed rule set and finder config are otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014v3vmV4GJNZvV9nPvnXokw