### PR TITLE
#4378 Keep the mobile main menu inside the viewport

### DIFF
--- a/resources/assets/css/sections/header.css
+++ b/resources/assets/css/sections/header.css
@@ -115,11 +115,17 @@
    in the brand row unclipped; menu dropdowns are static below lg, so they just add scroll height.
    siteheader.js publishes the exact height; the fallback covers layouts that render the header
    without that inline script. `dvh`, not `vh` - on mobile Safari `100vh` is the *large* viewport
-   and would overestimate, reintroducing the bug. Gated on `.show` so the overflow does not fight
-   `.collapsing { overflow: hidden }` and flash a scrollbar mid-animation. */
+   and would overestimate, reintroducing the bug. The cap covers `.collapsing` too - Bootstrap
+   animates to the *uncapped* scroll height, so without it the menu would swell past the viewport
+   and snap back the moment the animation finishes. The overflow stays off `.collapsing`, whose own
+   `overflow: hidden` then keeps a scrollbar from flashing mid-animation. */
 @media (max-width: 991.98px) {
-    .ksg-header .navbar-second .navbar-collapse.show {
+    .ksg-header .navbar-second .navbar-collapse.show,
+    .ksg-header .navbar-second .navbar-collapse.collapsing {
         max-height: var(--ksg-navbar-collapse-max-height, calc(100dvh - 5rem));
+    }
+
+    .ksg-header .navbar-second .navbar-collapse.show {
         overflow-y: auto;
         overscroll-behavior: contain;
     }

--- a/resources/assets/css/sections/header.css
+++ b/resources/assets/css/sections/header.css
@@ -108,17 +108,9 @@
     line-height: 1;
 }
 
-/* The open mobile main menu must stay reachable (#4378): the header is sticky at the top of the
-   viewport and the collapse expands in normal flow below the brand row, so any item past the
-   viewport bottom cannot be scrolled to - the page scroll moves the document, not the pinned
-   header. Capping the collapse itself (rather than the header) keeps the dungeon-context dropdown
-   in the brand row unclipped; menu dropdowns are static below lg, so they just add scroll height.
-   siteheader.js publishes the exact height; the fallback covers layouts that render the header
-   without that inline script. `dvh`, not `vh` - on mobile Safari `100vh` is the *large* viewport
-   and would overestimate, reintroducing the bug. The cap covers `.collapsing` too - Bootstrap
-   animates to the *uncapped* scroll height, so without it the menu would swell past the viewport
-   and snap back the moment the animation finishes. The overflow stays off `.collapsing`, whose own
-   `overflow: hidden` then keeps a scrollbar from flashing mid-animation. */
+/* Caps the open mobile menu to the viewport (#4378) - the sticky header doesn't scroll with the
+   page. `dvh` avoids Safari's oversized `100vh`; capped during `.collapsing` too so it doesn't
+   overshoot then snap back once the open animation finishes. */
 @media (max-width: 991.98px) {
     .ksg-header .navbar-second .navbar-collapse.show,
     .ksg-header .navbar-second .navbar-collapse.collapsing {

--- a/resources/assets/css/sections/header.css
+++ b/resources/assets/css/sections/header.css
@@ -107,3 +107,20 @@
     font-weight: 700;
     line-height: 1;
 }
+
+/* The open mobile main menu must stay reachable (#4378): the header is sticky at the top of the
+   viewport and the collapse expands in normal flow below the brand row, so any item past the
+   viewport bottom cannot be scrolled to - the page scroll moves the document, not the pinned
+   header. Capping the collapse itself (rather than the header) keeps the dungeon-context dropdown
+   in the brand row unclipped; menu dropdowns are static below lg, so they just add scroll height.
+   siteheader.js publishes the exact height; the fallback covers layouts that render the header
+   without that inline script. `dvh`, not `vh` - on mobile Safari `100vh` is the *large* viewport
+   and would overestimate, reintroducing the bug. Gated on `.show` so the overflow does not fight
+   `.collapsing { overflow: hidden }` and flash a scrollbar mid-animation. */
+@media (max-width: 991.98px) {
+    .ksg-header .navbar-second .navbar-collapse.show {
+        max-height: var(--ksg-navbar-collapse-max-height, calc(100dvh - 5rem));
+        overflow-y: auto;
+        overscroll-behavior: contain;
+    }
+}

--- a/resources/assets/js/custom/inline/common/general/siteheader.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.js
@@ -68,11 +68,11 @@ class CommonGeneralSiteheader extends InlineCode {
 
         // Publish the header's rendered height so dependents (e.g. the route sidebar) can
         // position themselves below it without hardcoded offsets.
-        this._resizeObserver = new ResizeObserver(this._reportHeaderHeight.bind(this));
-        this._resizeObserver.observe(this.header);
-        this._reportHeaderHeight();
-
         this._initNavbarCollapse();
+
+        this._resizeObserver = new ResizeObserver(this._onHeaderResized.bind(this));
+        this._resizeObserver.observe(this.header);
+        this._onHeaderResized();
 
         // The map view renders the header permanently shrunk - no scroll handling there
         this.shrinkTarget = this.header.classList.contains('ksg-header') ?
@@ -94,6 +94,16 @@ class CommonGeneralSiteheader extends InlineCode {
         }, {passive: true});
 
         this._updateShrink();
+    }
+
+    /**
+     * The header's own height transition (shrink/unshrink) moves the open menu's top edge, and so
+     * does anything else that reflows the bars - the observer catches every such change, which is
+     * why neither the shrink toggle nor the collapse animation needs its own hook or timer.
+     */
+    _onHeaderResized() {
+        this._reportHeaderHeight();
+        this._updateNavbarCollapseMaxHeight();
     }
 
     _reportHeaderHeight() {
@@ -120,10 +130,6 @@ class CommonGeneralSiteheader extends InlineCode {
             }
 
             this.shrinkTarget.classList.toggle('ksg-header--shrink', shrunk);
-
-            // The brand row changes height with the shrink, moving the collapse's top - an
-            // already open menu would otherwise keep a max height measured against the old row
-            this._updateNavbarCollapseMaxHeight();
         }
     }
 
@@ -140,11 +146,12 @@ class CommonGeneralSiteheader extends InlineCode {
             return;
         }
 
-        // Measured on show rather than shown: the collapse still has height 0 then, so its top
-        // is exactly the bottom of the brand row - and the cap is in place before the animation
+        // Bootstrap fires `show` before it makes the element visible, so this only seeds the
+        // estimate - the ResizeObserver refines it from the real geometry as the menu opens
         this.navbarCollapse.addEventListener('show.bs.collapse', this._updateNavbarCollapseMaxHeight.bind(this));
         this.navbarCollapse.addEventListener('hidden.bs.collapse', this._clearNavbarCollapseMaxHeight.bind(this));
 
+        // The header does not resize when only the viewport does (address bar, rotation)
         window.addEventListener('resize', this._updateNavbarCollapseMaxHeight.bind(this));
         window.addEventListener('orientationchange', this._updateNavbarCollapseMaxHeight.bind(this));
     }
@@ -156,11 +163,28 @@ class CommonGeneralSiteheader extends InlineCode {
 
         const maxHeight = calculateNavbarCollapseMaxHeight(
             window.innerHeight,
-            this.navbarCollapse.getBoundingClientRect().top,
+            this._navbarCollapseTop(),
             CommonGeneralSiteheader.NAVBAR_COLLAPSE_BOTTOM_MARGIN
         );
 
         document.documentElement.style.setProperty('--ksg-navbar-collapse-max-height', `${maxHeight}px`);
+    }
+
+    /**
+     * Where the menu's top edge is - or will be, while it is still closed.
+     *
+     * A closed collapse is `display: none` and reports an all-zero rect, which would pass for a
+     * menu starting at the very top of the viewport and yield a cap a whole header too large. The
+     * closed header's bottom edge is the same row bottom plus the navbar's bottom padding, so it
+     * errs a few pixels low - and erring low keeps every item reachable.
+     *
+     * @returns {number}
+     */
+    _navbarCollapseTop() {
+        const rect = this.navbarCollapse.getBoundingClientRect();
+
+        return rect.width === 0 && rect.height === 0 ?
+            this.header.getBoundingClientRect().bottom : rect.top;
     }
 
     _clearNavbarCollapseMaxHeight() {

--- a/resources/assets/js/custom/inline/common/general/siteheader.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.js
@@ -134,12 +134,7 @@ class CommonGeneralSiteheader extends InlineCode {
     }
 
     /**
-     * Keep the mobile main menu inside the viewport (#4378).
-     *
-     * Only the height is published - whether the cap applies at all is CSS's call (header.css
-     * gates it on the mobile breakpoint and on the menu being open), so the property is never
-     * cleared: it simply has no effect while the menu is closed or the navbar lays out as a
-     * single row, and it is always refreshed before the menu becomes visible again.
+     * Publishes the mobile main menu's max height (#4378); header.css decides when the cap applies.
      */
     _initNavbarCollapse() {
         this.navbarCollapse = this.header.querySelector('.navbar-second .navbar-collapse');
@@ -171,13 +166,7 @@ class CommonGeneralSiteheader extends InlineCode {
     }
 
     /**
-     * Where the menu's top edge is - or will be, while it is still closed.
-     *
-     * A closed collapse is `display: none` and reports an all-zero rect, which would pass for a
-     * menu starting at the very top of the viewport and yield a cap a whole header too large. The
-     * closed header's bottom edge is the same row bottom plus the navbar's bottom padding, so it
-     * errs a few pixels low - and erring low keeps every item reachable.
-     *
+     * Where the menu's top edge is (or will be while closed - falls back to the header's bottom edge).
      * @returns {number}
      */
     _navbarCollapseTop() {

--- a/resources/assets/js/custom/inline/common/general/siteheader.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.js
@@ -21,6 +21,22 @@ function shouldShrinkHeader(scrollY, currentlyShrunk, shrinkAt = 140, unshrinkAt
     return scrollY > shrinkAt;
 }
 
+/**
+ * The height the mobile navbar collapse may occupy before it must scroll internally.
+ *
+ * The header is sticky at the top of the viewport and the collapse expands in normal flow below
+ * the brand row, so anything past the viewport bottom is unreachable - the page scroll moves the
+ * document, not the pinned header (#4378).
+ *
+ * @param {number} viewportHeight The dynamic viewport height (window.innerHeight)
+ * @param {number} collapseTop The collapse's distance from the top of the viewport
+ * @param {number} bottomMargin Breathing room kept below the last menu item
+ * @returns {number}
+ */
+function calculateNavbarCollapseMaxHeight(viewportHeight, collapseTop, bottomMargin = 8) {
+    return Math.max(0, Math.floor(viewportHeight - collapseTop - bottomMargin));
+}
+
 class CommonGeneralSiteheader extends InlineCode {
     /**
      * Never shrink when the page barely scrolls - the height change itself would make up
@@ -34,6 +50,11 @@ class CommonGeneralSiteheader extends InlineCode {
      * growing - and anchoring keeps re-evaluating - for its whole duration.
      */
     static SCROLL_ANCHOR_SUPPRESSION_MS = 400;
+
+    /**
+     * Breathing room kept between the last item of the open mobile menu and the viewport bottom.
+     */
+    static NAVBAR_COLLAPSE_BOTTOM_MARGIN = 8;
 
     activate() {
         super.activate();
@@ -50,6 +71,8 @@ class CommonGeneralSiteheader extends InlineCode {
         this._resizeObserver = new ResizeObserver(this._reportHeaderHeight.bind(this));
         this._resizeObserver.observe(this.header);
         this._reportHeaderHeight();
+
+        this._initNavbarCollapse();
 
         // The map view renders the header permanently shrunk - no scroll handling there
         this.shrinkTarget = this.header.classList.contains('ksg-header') ?
@@ -97,7 +120,51 @@ class CommonGeneralSiteheader extends InlineCode {
             }
 
             this.shrinkTarget.classList.toggle('ksg-header--shrink', shrunk);
+
+            // The brand row changes height with the shrink, moving the collapse's top - an
+            // already open menu would otherwise keep a max height measured against the old row
+            this._updateNavbarCollapseMaxHeight();
         }
+    }
+
+    /**
+     * Keep the mobile main menu inside the viewport (#4378).
+     *
+     * Only the height is published - whether the cap applies at all is CSS's call (header.css
+     * gates it on the mobile breakpoint), so crossing into desktop with the menu open cannot
+     * leave a stale cap behind on a navbar that lays out as a single row.
+     */
+    _initNavbarCollapse() {
+        this.navbarCollapse = this.header.querySelector('.navbar-second .navbar-collapse');
+        if (this.navbarCollapse === null) {
+            return;
+        }
+
+        // Measured on show rather than shown: the collapse still has height 0 then, so its top
+        // is exactly the bottom of the brand row - and the cap is in place before the animation
+        this.navbarCollapse.addEventListener('show.bs.collapse', this._updateNavbarCollapseMaxHeight.bind(this));
+        this.navbarCollapse.addEventListener('hidden.bs.collapse', this._clearNavbarCollapseMaxHeight.bind(this));
+
+        window.addEventListener('resize', this._updateNavbarCollapseMaxHeight.bind(this));
+        window.addEventListener('orientationchange', this._updateNavbarCollapseMaxHeight.bind(this));
+    }
+
+    _updateNavbarCollapseMaxHeight() {
+        if (!this.navbarCollapse) {
+            return;
+        }
+
+        const maxHeight = calculateNavbarCollapseMaxHeight(
+            window.innerHeight,
+            this.navbarCollapse.getBoundingClientRect().top,
+            CommonGeneralSiteheader.NAVBAR_COLLAPSE_BOTTOM_MARGIN
+        );
+
+        document.documentElement.style.setProperty('--ksg-navbar-collapse-max-height', `${maxHeight}px`);
+    }
+
+    _clearNavbarCollapseMaxHeight() {
+        document.documentElement.style.removeProperty('--ksg-navbar-collapse-max-height');
     }
 
     /**
@@ -135,5 +202,5 @@ class CommonGeneralSiteheader extends InlineCode {
 // Guarded export for the test runner (Vitest). This is a no-op in the browser,
 // where `module` is undefined, so it does not affect the concatenated bundle.
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = {CommonGeneralSiteheader, shouldShrinkHeader};
+    module.exports = {CommonGeneralSiteheader, shouldShrinkHeader, calculateNavbarCollapseMaxHeight};
 }

--- a/resources/assets/js/custom/inline/common/general/siteheader.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.js
@@ -137,8 +137,9 @@ class CommonGeneralSiteheader extends InlineCode {
      * Keep the mobile main menu inside the viewport (#4378).
      *
      * Only the height is published - whether the cap applies at all is CSS's call (header.css
-     * gates it on the mobile breakpoint), so crossing into desktop with the menu open cannot
-     * leave a stale cap behind on a navbar that lays out as a single row.
+     * gates it on the mobile breakpoint and on the menu being open), so the property is never
+     * cleared: it simply has no effect while the menu is closed or the navbar lays out as a
+     * single row, and it is always refreshed before the menu becomes visible again.
      */
     _initNavbarCollapse() {
         this.navbarCollapse = this.header.querySelector('.navbar-second .navbar-collapse');
@@ -149,7 +150,6 @@ class CommonGeneralSiteheader extends InlineCode {
         // Bootstrap fires `show` before it makes the element visible, so this only seeds the
         // estimate - the ResizeObserver refines it from the real geometry as the menu opens
         this.navbarCollapse.addEventListener('show.bs.collapse', this._updateNavbarCollapseMaxHeight.bind(this));
-        this.navbarCollapse.addEventListener('hidden.bs.collapse', this._clearNavbarCollapseMaxHeight.bind(this));
 
         // The header does not resize when only the viewport does (address bar, rotation)
         window.addEventListener('resize', this._updateNavbarCollapseMaxHeight.bind(this));
@@ -185,10 +185,6 @@ class CommonGeneralSiteheader extends InlineCode {
 
         return rect.width === 0 && rect.height === 0 ?
             this.header.getBoundingClientRect().bottom : rect.top;
-    }
-
-    _clearNavbarCollapseMaxHeight() {
-        document.documentElement.style.removeProperty('--ksg-navbar-collapse-max-height');
     }
 
     /**

--- a/resources/assets/js/custom/inline/common/general/siteheader.test.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.test.js
@@ -209,10 +209,15 @@ describe('calculateNavbarCollapseMaxHeight', () => {
 
 describe('CommonGeneralSiteheader mobile menu height', () => {
     /**
-     * @param {number} collapseTop
+     * Builds a header whose collapse reports a rect the way a real browser does: all zeros while
+     * closed (Bootstrap fires `show.bs.collapse` before the element stops being `display: none`),
+     * the real top once open.
+     *
+     * @param {number} openCollapseTop
+     * @param {number} closedHeaderBottom
      * @returns {CommonGeneralSiteheader}
      */
-    function makeSiteheaderWithCollapse(collapseTop = 56) {
+    function makeSiteheaderWithCollapse(openCollapseTop = 56, closedHeaderBottom = 64) {
         document.body.innerHTML = `
             <div id="site_header" class="ksg-header">
                 <nav class="navbar navbar-second">
@@ -225,10 +230,14 @@ describe('CommonGeneralSiteheader mobile menu height', () => {
         siteheader.shrinkTarget = siteheader.header;
         siteheader._initNavbarCollapse();
 
-        // jsdom lays nothing out, so the collapse's position is stubbed the way the shrink
-        // tests stub scrollHeight/innerHeight
+        // jsdom lays nothing out, so geometry is stubbed the way the shrink tests stub
+        // scrollHeight/innerHeight
+        vi.spyOn(siteheader.header, 'getBoundingClientRect')
+            .mockReturnValue({top: 0, bottom: closedHeaderBottom, width: 390, height: closedHeaderBottom});
         vi.spyOn(siteheader.navbarCollapse, 'getBoundingClientRect')
-            .mockReturnValue({top: collapseTop});
+            .mockReturnValue({top: 0, bottom: 0, width: 0, height: 0});
+        siteheader.openCollapse = () => siteheader.navbarCollapse.getBoundingClientRect
+            .mockReturnValue({top: openCollapseTop, bottom: 400, width: 390, height: 400 - openCollapseTop});
         window.innerHeight = 640;
 
         return siteheader;
@@ -238,14 +247,29 @@ describe('CommonGeneralSiteheader mobile menu height', () => {
         document.documentElement.style.removeProperty('--ksg-navbar-collapse-max-height');
     });
 
-    it('initNavbarCollapse_givenMenuOpens_capsItToTheVisibleViewport', () => {
-        // Arrange
+    it('showCollapse_givenTheMenuIsStillDisplayNone_capsItFromTheHeaderInsteadOfTheZeroRect', () => {
+        // Arrange: Bootstrap triggers `show` before it removes `.collapse`, so the element is
+        // still `display: none` and reports an all-zero rect
         const siteheader = makeSiteheaderWithCollapse();
 
         // Act
         siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
 
-        // Assert: 640 viewport - 56 brand row - 8 margin
+        // Assert: 640 viewport - 64 closed header - 8 margin. Trusting the zero rect would give
+        // 632px and leave a header's worth of menu below the fold - the bug itself (#4378)
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('568px');
+    });
+
+    it('onHeaderResized_givenTheMenuIsOpen_capsItToTheVisibleViewport', () => {
+        // Arrange: the menu opening resizes the header, which is what drives the refinement
+        const siteheader = makeSiteheaderWithCollapse();
+        siteheader.openCollapse();
+
+        // Act
+        siteheader._updateNavbarCollapseMaxHeight();
+
+        // Assert: 640 viewport - 56 collapse top - 8 margin
         expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
             .toBe('576px');
     });
@@ -253,7 +277,8 @@ describe('CommonGeneralSiteheader mobile menu height', () => {
     it('initNavbarCollapse_givenViewportResizedWhileOpen_recalculatesTheCap', () => {
         // Arrange: menu open on a tall viewport, then the browser chrome expands
         const siteheader = makeSiteheaderWithCollapse();
-        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
+        siteheader.openCollapse();
+        siteheader._updateNavbarCollapseMaxHeight();
         window.innerHeight = 400;
 
         // Act
@@ -277,30 +302,30 @@ describe('CommonGeneralSiteheader mobile menu height', () => {
             .toBe('');
     });
 
-    it('updateShrink_givenHeaderUnshrinksWithTheMenuOpen_recalculatesTheCap', () => {
-        // Arrange: menu opened while the header was shrunk, then scrolled back to the top -
-        // the brand row regains its padding and pushes the collapse down
+    it('onHeaderResized_givenTheHeaderGrowsBackWithTheMenuOpen_recalculatesTheCap', () => {
+        // Arrange: the menu was opened while the header was shrunk; scrolling back to the top
+        // gives the brand row its padding back and pushes the menu down. The ResizeObserver
+        // fires on that height change - a cap measured against the shrunk row would be too
+        // large and put the bottom items back out of reach
         const siteheader = makeSiteheaderWithCollapse(48);
-        siteheader.shrinkTarget.classList.add('ksg-header--shrink');
-        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
+        siteheader.openCollapse();
+        siteheader._onHeaderResized();
         expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
             .toBe('584px');
 
-        siteheader.navbarCollapse.getBoundingClientRect.mockReturnValue({top: 64});
-        window.scrollY = 0;
-        vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(5000);
+        siteheader.navbarCollapse.getBoundingClientRect
+            .mockReturnValue({top: 64, bottom: 400, width: 390, height: 336});
 
         // Act
-        siteheader._updateShrink();
+        siteheader._onHeaderResized();
 
-        // Assert: keeping the shrunk measurement would leave the last items below the fold
-        expect(siteheader.shrinkTarget.classList.contains('ksg-header--shrink')).toBe(false);
+        // Assert
         expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
             .toBe('568px');
     });
 
     it('initNavbarCollapse_givenNoCollapseInTheHeader_doesNothing', () => {
-        // Arrange: the map header renders without a main navbar collapse
+        // Arrange: a header rendered without a main navbar collapse
         document.body.innerHTML = '<div id="site_header" class="ksg-header"></div>';
         const siteheader = new CommonGeneralSiteheader('siteheader', 'common/general/siteheader', {});
         siteheader.header = document.getElementById('site_header');

--- a/resources/assets/js/custom/inline/common/general/siteheader.test.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.test.js
@@ -8,7 +8,7 @@
 const {InlineCode}    = require('../../inlinecode');
 globalThis.InlineCode = InlineCode;
 
-const {CommonGeneralSiteheader, shouldShrinkHeader} = require('./siteheader');
+const {CommonGeneralSiteheader, shouldShrinkHeader, calculateNavbarCollapseMaxHeight} = require('./siteheader');
 
 describe('shouldShrinkHeader', () => {
     it('shouldShrinkHeader_givenTopOfPageNotShrunk_returnsFalse', () => {
@@ -187,5 +187,131 @@ describe('CommonGeneralSiteheader scroll anchoring', () => {
 
         // Assert: a stale timer must not cut the second suppression window short
         expect(document.documentElement.style.overflowAnchor).toBe('none');
+    });
+});
+
+describe('calculateNavbarCollapseMaxHeight', () => {
+    it('calculateNavbarCollapseMaxHeight_givenRoomBelowTheBrandRow_returnsTheRemainingViewport', () => {
+        // A 640px tall phone viewport with a 56px brand row above the collapse
+        expect(calculateNavbarCollapseMaxHeight(640, 56, 8)).toBe(576);
+    });
+
+    it('calculateNavbarCollapseMaxHeight_givenFractionalLayout_roundsDownToStayInsideTheViewport', () => {
+        // Rounding up would push the last item back below the fold - the whole bug (#4378)
+        expect(calculateNavbarCollapseMaxHeight(640, 55.6, 8)).toBe(576);
+    });
+
+    it('calculateNavbarCollapseMaxHeight_givenNoRoomLeft_clampsAtZero', () => {
+        // A viewport shorter than the header itself must not produce a negative max-height
+        expect(calculateNavbarCollapseMaxHeight(50, 56, 8)).toBe(0);
+    });
+});
+
+describe('CommonGeneralSiteheader mobile menu height', () => {
+    /**
+     * @param {number} collapseTop
+     * @returns {CommonGeneralSiteheader}
+     */
+    function makeSiteheaderWithCollapse(collapseTop = 56) {
+        document.body.innerHTML = `
+            <div id="site_header" class="ksg-header">
+                <nav class="navbar navbar-second">
+                    <div class="collapse navbar-collapse" id="mainNavbar"></div>
+                </nav>
+            </div>`;
+
+        const siteheader = new CommonGeneralSiteheader('siteheader', 'common/general/siteheader', {});
+        siteheader.header = document.getElementById('site_header');
+        siteheader.shrinkTarget = siteheader.header;
+        siteheader._initNavbarCollapse();
+
+        // jsdom lays nothing out, so the collapse's position is stubbed the way the shrink
+        // tests stub scrollHeight/innerHeight
+        vi.spyOn(siteheader.navbarCollapse, 'getBoundingClientRect')
+            .mockReturnValue({top: collapseTop});
+        window.innerHeight = 640;
+
+        return siteheader;
+    }
+
+    afterEach(() => {
+        document.documentElement.style.removeProperty('--ksg-navbar-collapse-max-height');
+    });
+
+    it('initNavbarCollapse_givenMenuOpens_capsItToTheVisibleViewport', () => {
+        // Arrange
+        const siteheader = makeSiteheaderWithCollapse();
+
+        // Act
+        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
+
+        // Assert: 640 viewport - 56 brand row - 8 margin
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('576px');
+    });
+
+    it('initNavbarCollapse_givenViewportResizedWhileOpen_recalculatesTheCap', () => {
+        // Arrange: menu open on a tall viewport, then the browser chrome expands
+        const siteheader = makeSiteheaderWithCollapse();
+        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
+        window.innerHeight = 400;
+
+        // Act
+        window.dispatchEvent(new Event('resize'));
+
+        // Assert
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('336px');
+    });
+
+    it('initNavbarCollapse_givenMenuClosed_dropsTheCapAgain', () => {
+        // Arrange
+        const siteheader = makeSiteheaderWithCollapse();
+        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
+
+        // Act
+        siteheader.navbarCollapse.dispatchEvent(new Event('hidden.bs.collapse'));
+
+        // Assert: a stale cap would shrink the menu the next time it opens at a different offset
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('');
+    });
+
+    it('updateShrink_givenHeaderUnshrinksWithTheMenuOpen_recalculatesTheCap', () => {
+        // Arrange: menu opened while the header was shrunk, then scrolled back to the top -
+        // the brand row regains its padding and pushes the collapse down
+        const siteheader = makeSiteheaderWithCollapse(48);
+        siteheader.shrinkTarget.classList.add('ksg-header--shrink');
+        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('584px');
+
+        siteheader.navbarCollapse.getBoundingClientRect.mockReturnValue({top: 64});
+        window.scrollY = 0;
+        vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(5000);
+
+        // Act
+        siteheader._updateShrink();
+
+        // Assert: keeping the shrunk measurement would leave the last items below the fold
+        expect(siteheader.shrinkTarget.classList.contains('ksg-header--shrink')).toBe(false);
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('568px');
+    });
+
+    it('initNavbarCollapse_givenNoCollapseInTheHeader_doesNothing', () => {
+        // Arrange: the map header renders without a main navbar collapse
+        document.body.innerHTML = '<div id="site_header" class="ksg-header"></div>';
+        const siteheader = new CommonGeneralSiteheader('siteheader', 'common/general/siteheader', {});
+        siteheader.header = document.getElementById('site_header');
+
+        // Act
+        siteheader._initNavbarCollapse();
+        siteheader._updateNavbarCollapseMaxHeight();
+
+        // Assert
+        expect(siteheader.navbarCollapse).toBeNull();
+        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
+            .toBe('');
     });
 });

--- a/resources/assets/js/custom/inline/common/general/siteheader.test.js
+++ b/resources/assets/js/custom/inline/common/general/siteheader.test.js
@@ -289,19 +289,6 @@ describe('CommonGeneralSiteheader mobile menu height', () => {
             .toBe('336px');
     });
 
-    it('initNavbarCollapse_givenMenuClosed_dropsTheCapAgain', () => {
-        // Arrange
-        const siteheader = makeSiteheaderWithCollapse();
-        siteheader.navbarCollapse.dispatchEvent(new Event('show.bs.collapse'));
-
-        // Act
-        siteheader.navbarCollapse.dispatchEvent(new Event('hidden.bs.collapse'));
-
-        // Assert: a stale cap would shrink the menu the next time it opens at a different offset
-        expect(document.documentElement.style.getPropertyValue('--ksg-navbar-collapse-max-height'))
-            .toBe('');
-    });
-
     it('onHeaderResized_givenTheHeaderGrowsBackWithTheMenuOpen_recalculatesTheCap', () => {
         // Arrange: the menu was opened while the header was shrunk; scrolling back to the top
         // gives the brand row its padding back and pushes the menu down. The ResizeObserver


### PR DESCRIPTION
Closes #4378

## Problem

The site header is `position: sticky; top: 0` and the Bootstrap navbar collapse expands in normal document flow below the brand row. With enough menu items — extra admin entries, a short/landscape viewport — the bottom of the open menu ends up past the bottom of the viewport, and there is no way to reach it: the page scroll moves the document, not the pinned header, and the collapse itself had no overflow of its own.

## Fix

Below the `lg` breakpoint the open collapse gets a max height and scrolls internally.

- The cap is put on the collapse rather than on the header: capping the header would clip the mobile dungeon-context dropdown, which lives in the brand row and is deliberately `position: absolute` there. Dropdowns *inside* the collapse are static below `lg`, so they simply add scrollable height.
- The cap covers `.collapsing` as well as `.show`, because Bootstrap animates the collapse to its *uncapped* scroll height — gated on `.show` alone the menu swelled well past the viewport and snapped back when the animation finished. The `overflow-y` stays on `.show` only, so `.collapsing`'s own `overflow: hidden` still keeps a scrollbar from flashing mid-animation.
- `siteheader.js` publishes the remaining space as `--ksg-navbar-collapse-max-height`. The exact value comes from the ResizeObserver that already watches the header — it fires as the collapse animates open and again whenever the shrink/unshrink transition moves the menu's top edge, so neither needs its own hook or timer. `show.bs.collapse` only seeds an estimate, and it deliberately does **not** trust the collapse's rect: Bootstrap fires that event *before* it removes `.collapse`, so the element is still `display: none` and reports an all-zero rect. The closed-state fallback is the header's own bottom edge, which errs a few pixels low — and erring low keeps every item reachable.
- Publishing a custom property instead of an inline style means the media query stays in charge: crossing into desktop with the menu open cannot leave a stale cap on a navbar that lays out as a single row. It is never cleared for the same reason — it has no effect while the menu is closed, and is always refreshed before the menu becomes visible again.
- The CSS fallback `calc(100dvh - 5rem)` covers any layout rendering the header without that inline script. `dvh`, not `vh`: on mobile Safari `100vh` is the *large* viewport and would overestimate, reintroducing the bug.

## Testing

**Unit** — `vitest run resources/assets/js/custom/inline/common/general/siteheader.test.js`: 21 passed. New cases cover the pure `calculateNavbarCollapseMaxHeight` (remaining viewport, rounding down, clamping at 0) and the DOM wiring (the closed-menu zero rect falling back to the header bottom, refinement once open, recompute on viewport resize and on the header growing back with the menu open, no-op when the header has no collapse).

**Real browser** — headless Chrome at 390×500 against a harness built from the real `bootstrap.min.css` / `bootstrap.bundle.min.js`, this branch's `header.css` and `siteheader.js`, with 20 menu items:

| | peak height while opening | menu bottom ≤ viewport | scrolls internally | last item reachable |
|---|---|---|---|---|
| without the new rule | 790px | ✗ (849px vs 500px) | ✗ | ✗ |
| capped on `.show` only | 790px, snapping back to 442px | ✓ | ✓ | ✓ |
| as shipped | 442px | ✓ (491px) | ✓ (800px content in 442px) | ✓ |

Closing still animates back to zero, and the run reports no console errors or `pageerror`s (in particular no ResizeObserver loop warning from recomputing inside the observer).

**Build** — `node scripts/build/build.mjs` succeeds and the rule lands in the concatenated custom stylesheet.

Not exercised against the live app (this worktree has no running stack), so a glance at the real header on a phone is still worth doing before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QVEMcRjxXx1LwczWpqUfc